### PR TITLE
Add theming-support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,11 @@ In your local settings that star-imports from an `argus-server`_ settings file::
     ROOT_URLCONF = "urls.py"
     MIDDLEWARE += ["django_htmx.middleware.HtmxMiddleware"]
 
+In the same file, add a copy of the entirety of ``TEMPLATES``. Choose one of
+the functions in ``argus_htmx.context_processors``. In the entry for
+``django.template.backends.django.DjangoTemplates``, append the full dotted
+path to the end of the ``context_processors`` list.
+
 Next to ``localsettings.py`` create an ``urls.py`` containing::
 
    from argus.site.urls import urlpatterns
@@ -56,9 +61,12 @@ Next to ``localsettings.py`` create an ``urls.py`` containing::
 With EXTRA_APPS
 ~~~~~~~~~~~~~~~
 
+Choose one of the functions in ``argus_htmx.context_processors``, exemplified
+by "theme_via_GET" below.
+
 In your environment variables::
 
-    ARGUS_EXTRA_APPS = '[{"app_name": "django_htmx"},{"app_name": "argus_htmx","urls": {"path": "", "urlpatterns_module": "argus_htmx.urls"}}]'
+    ARGUS_EXTRA_APPS = '[{"app_name": "django_htmx"}, {"app_name": "argus_htmx", "urls": {"path": "", "urlpatterns_module": "argus_htmx.urls"}, "context_processors": ["arguss_htmx.context_processor.theme_via_GET"]}]'
 
 In your local settings that star-imports from an `argus-server`_ settings file::
 

--- a/src/argus_htmx/context_processors.py
+++ b/src/argus_htmx/context_processors.py
@@ -1,5 +1,13 @@
-# Should probably be in a theming-app
+"""
+This should probably be in a separate 3rd party theming-app!
 
+How to use:
+
+Update the "context_processors" list for the TEMPLATES-backend
+``django.template.backends.django.DjangoTemplates`` with *one* of these.
+
+See django settings for ``TEMPLATES``.
+"""
 
 def theme_via_GET(request):
     theme = request.GET.get("theme", None)

--- a/src/argus_htmx/context_processors.py
+++ b/src/argus_htmx/context_processors.py
@@ -1,0 +1,14 @@
+# Should probably be in a theming-app
+
+
+DEFAULT_THEME = "default"
+
+
+def theme_via_GET(request):
+    theme = request.GET("theme", DEFAULT_THEME)
+    return {"theme": theme}
+
+
+def theme_via_session(request):
+    theme = request.session.get("theme", DEFAULT_THEME)
+    return {"theme": theme}

--- a/src/argus_htmx/context_processors.py
+++ b/src/argus_htmx/context_processors.py
@@ -1,14 +1,11 @@
 # Should probably be in a theming-app
 
 
-DEFAULT_THEME = "default"
-
-
 def theme_via_GET(request):
-    theme = request.GET("theme", DEFAULT_THEME)
+    theme = request.GET.get("theme", None)
     return {"theme": theme}
 
 
 def theme_via_session(request):
-    theme = request.session.get("theme", DEFAULT_THEME)
+    theme = request.session.get("theme", None)
     return {"theme": theme}

--- a/src/argus_htmx/static/color-schemes/blue.css
+++ b/src/argus_htmx/static/color-schemes/blue.css
@@ -1,0 +1,7 @@
+:root {
+  --main-bg-color: lightblue;
+  --main-fg-color: darkblue;
+  --main-link-color: blue;
+  --nav-bg-color: darkblue;
+  --nav-fg-color: cyan;
+}

--- a/src/argus_htmx/static/color-schemes/dark.css
+++ b/src/argus_htmx/static/color-schemes/dark.css
@@ -1,0 +1,7 @@
+:root {
+  --main-bg-color: #121212;
+  --main-fg-color: #eee;
+  --main-link-color: #809fff;
+  --nav-bg-color: black;
+  --nav-fg-color: #eee;
+}

--- a/src/argus_htmx/static/color-schemes/light.css
+++ b/src/argus_htmx/static/color-schemes/light.css
@@ -1,0 +1,7 @@
+:root {
+  --main-bg-color: white;
+  --main-fg-color: black;
+  --main-link-color: blue;
+  --nav-bg-color: lightgrey;
+  --nav-fg-color: black;
+}

--- a/src/argus_htmx/templates/htmx/base.html
+++ b/src/argus_htmx/templates/htmx/base.html
@@ -2,14 +2,27 @@
 
 {% block head %}
 <script src="https://unpkg.com/htmx.org@1.9.12" integrity="sha384-ujb1lZYygJmzgSwoxRggbCHcjc0rB2XoQrxeTUQyRjrOnlCoYta87iKBWq3EsdM2" crossorigin="anonymous"></script>
+<link rel="stylesheet" href="/static/color-schemes/{{ theme|default:'light' }}.css" />
+<link rel="stylesheet" href="/static/color-schemes/light.css" media="(prefers-color-scheme: light)" />
+<link rel="stylesheet" href="/static/color-schemes/dark.css" media="(prefers-color-scheme: dark)" />
 <style>
-section { border: 1px solid blue; }
+* {
+  background-color: var(--main-bg-color);
+  color: var(--main-fg-color);
+}
+
 header {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
+  font-weight: bold; 
+  background-color: var(--nav-bg-color);
+  color: var(--nav-fg-color);
 }
-header > * { background-color: lightgrey }
+
+a { color: var(--main-link-color); }
+
+section { border: 1px solid blue; }
 </style>
 {% endblock head %}
 

--- a/src/argus_htmx/templates/htmx/base.html
+++ b/src/argus_htmx/templates/htmx/base.html
@@ -2,9 +2,12 @@
 
 {% block head %}
 <script src="https://unpkg.com/htmx.org@1.9.12" integrity="sha384-ujb1lZYygJmzgSwoxRggbCHcjc0rB2XoQrxeTUQyRjrOnlCoYta87iKBWq3EsdM2" crossorigin="anonymous"></script>
-<link rel="stylesheet" href="/static/color-schemes/{{ theme|default:'light' }}.css" />
+{% if theme %}
+<link rel="stylesheet" href="/static/color-schemes/{{ theme }}.css" />
+{% else %}
 <link rel="stylesheet" href="/static/color-schemes/light.css" media="(prefers-color-scheme: light)" />
 <link rel="stylesheet" href="/static/color-schemes/dark.css" media="(prefers-color-scheme: dark)" />
+{% endif %}
 <style>
 * {
   background-color: var(--main-bg-color);
@@ -32,6 +35,7 @@ section { border: 1px solid blue; }
 <div>Timeslots</div>
 <div>Profiles</div>
 <div>{% block userlink %}
+Theme: "{{ theme }}"
 {% if request.user.is_authenticated %}
 {{ request.user }}
 <form action="{% url "htmx:logout" %}" method="POST">

--- a/src/argus_htmx/views.py
+++ b/src/argus_htmx/views.py
@@ -27,7 +27,9 @@ def incidents(request):
 # fetch with htmx
 def incident_row(request, pk: int):
     incident = get_object_or_404(Incident, d=pk)
-    context = {"incident": incident}
+    context = {
+        "incident": incident,
+    }
     return render(request, "htmx/incidents/_incident_row.html", context=context)
 
 


### PR DESCRIPTION
Depends on Uninett/Argus#810

Use a context processor to set the variable "theme" in all contexts. The variable corresponds to a file in `static/color-schemes/`.

Included themes: dark, light, blue, where dark supports darkmode and light is the default.

How to use: add one of the included context processors either depending on #810 or manually.

Testing with GET: use the "argus_htmx.context_processors.theme_via_GET" context processor and suffix `?theme=SOMECOLOR` to any url.

Testing with session: use the "argus_htmx.context_processors.theme_via_session" context processor and set the correct key in your session like so: `request.session["theme"] = "SOMECOLOR"`