### PR TITLE
Setup testing with tox

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+import os
+import sys
+
+import django
+from django.conf import settings
+from django.test.utils import get_runner
+
+if __name__ == "__main__":
+    os.environ["DJANGO_SETTINGS_MODULE"] = "tests.settings"
+    django.setup()
+    TestRunner = get_runner(settings)
+    test_runner = TestRunner()
+    failures = test_runner.run_tests(["tests"])
+    sys.exit(bool(failures))

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,0 +1,15 @@
+SECRET_KEY = "fake-key"
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}
+INSTALLED_APPS = [
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+
+#     "argus.auth",
+    "tests",
+]
+ROOT_URLCONF = "tests.urls"

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path, include
+
+app_name = "htmx"
+urlpatterns = [
+    path("accounts/", include("django.contrib.auth.urls")),
+]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+requires =
+    tox>=4
+
+env_list = py{310,311,312}-django{42,50}
+
+[testenv]
+setenv =
+    PYTHONPATH = {toxinidir}/src
+commands =
+    python runtests.py
+deps =
+    django42: django>=4.2,<5
+    django50: django>=5.0,<5.1


### PR DESCRIPTION
This setup will work if *not* testing anything that uses imports from argus-server. If importing anything from argus-server it becomes necessary to expand the settings-file and switch to an actual postgres as the test database.