### PR TITLE
Add middleware for forcing logins, w/tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "argus-server",
+    "argus-server>=1.20.0",
     "django-htmx",
     # The next is for python_version < 3.12 but we simplify code by always needing it
     "importlib_resources>=5.12",

--- a/src/argus_htmx/middleware.py
+++ b/src/argus_htmx/middleware.py
@@ -1,0 +1,47 @@
+from django.conf import settings
+from django.contrib.auth.views import redirect_to_login
+from django.utils.deprecation import MiddlewareMixin
+from django.utils.encoding import force_str
+
+
+class LoginRequiredMiddleware:
+
+    def __init__(self, get_response):
+        self.public_urls = getattr(settings, 'PUBLIC_URLS', ())
+        self.login_url = force_str(settings.LOGIN_URL)
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return response
+
+    def process_view(self, request, view_func, _view_args, _view_kwargs):
+        assert hasattr(request, 'user'), (
+            "The LoginRequiredMiddleware requires authentication middleware "
+            "to be installed. Edit your MIDDLEWARE%s setting to insert "
+            "'django.contrib.auth.middleware.AuthenticationMiddleware' "
+            "before this middleware." % (
+            "_CLASSES" if settings.MIDDLEWARE is None else ""
+            )
+        )
+
+        # If path is public, allow
+        for url in self.public_urls:
+            if request.path.startswith(url):
+                return None
+
+        # If CBV has the attribute login_required == False, allow
+        view_class = getattr(view_func, 'view_class', None)
+        if view_class and not getattr(view_class, 'login_required', True):
+            return None
+
+        # If view_func.login_required == False, allow
+        if not getattr(view_func, 'login_required', True):
+            return None
+
+        # Allow authenticated users
+        if request.user.is_authenticated:
+            return None
+
+        # Redirect unauthenticated users to login page
+        return redirect_to_login(request.get_full_path(), self.login_url, 'next')

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,42 @@
+from unittest.mock import Mock
+
+from django import test
+from django.http import HttpResponseRedirect
+from django.test.client import RequestFactory
+
+from argus_htmx.middleware import LoginRequiredMiddleware
+
+
+class TestLoginRequiredMiddleware(test.TestCase):
+    def setUp(self):
+        request = RequestFactory().get('/foo')
+        request.login_url = '/login'
+        request.user = Mock()
+        request.get_full_path = Mock(return_value='/bar')
+        self.request = request
+
+    def test_process_view_login_required_false(self):
+        view_func = lambda : None
+        view_func.login_required = False
+        result = LoginRequiredMiddleware(lambda x: x).process_view(self.request, view_func, None, {})
+        self.assertIsNone(result)
+
+    @test.override_settings(PUBLIC_URLS=('/foo',))
+    def test_process_view_public_urls(self):
+        view_func = lambda : None
+        result = LoginRequiredMiddleware(lambda x: x).process_view(self.request, view_func, None, {})
+        self.assertIsNone(result)
+
+    def test_process_view_authenticated(self):
+        view_func = lambda : None
+        self.request.user.is_authenticated = True
+        result = LoginRequiredMiddleware(lambda x: x).process_view(self.request, view_func, None, {})
+        self.assertIsNone(result)
+        delattr(self.request.user, 'is_authenticated')
+
+    def test_process_view_redirect(self):
+        view_func = lambda : None
+        self.request.user.is_authenticated = False
+        result = LoginRequiredMiddleware(lambda x: x).process_view(self.request, view_func, None, {})
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, HttpResponseRedirect)


### PR DESCRIPTION
For this to work, change the following settings:
```
LOGIN_URL = "/accounts/login"
PUBLIC_URLS = [
    "/accounts/login",
    "/api",
]
MIDDLEWARE += ["argus_htmx.middleware.LoginRequiredMiddleware"]
```

Urls in `PUBLIC_URLS` are ignored by the middleware. Likewise, if the view has the attribute `login_required` set to "False", this middleware is skipped. If neither holds an unauthenticated user is redirected to LOGIN_URL.

(argus-server needs to mark "/" as "login_required = False" and any public urls not in the API.)