### PR TITLE
Add box for filtering incidents to incident-list

### DIFF
--- a/src/argus_htmx/incidents/filter.py
+++ b/src/argus_htmx/incidents/filter.py
@@ -1,0 +1,70 @@
+from django import forms
+
+from argus.filter import get_filter_backend
+from argus.incident.constants import INCIDENT_LEVEL_CHOICES, MAX_INCIDENT_LEVEL
+from argus.incident.models import SourceSystem
+
+
+filter_backend = get_filter_backend()
+QuerySetFilter = filter_backend.QuerySetFilter
+
+
+class IncidentFilterForm(forms.Form):
+    open = forms.BooleanField(required=False)
+    closed = forms.BooleanField(required=False)
+    acked = forms.BooleanField(required=False)
+    unacked = forms.BooleanField(required=False)
+    source = forms.MultipleChoiceField(
+        choices=tuple(SourceSystem.objects.values_list("id", "name")),
+        required=False,
+    )
+    maxlevel = forms.ChoiceField(
+        choices=((1, 1), (2, 2), (3, 3), (4, 4), (5, 5)),  # fix this, use constant
+        label="Level <=",
+        initial=MAX_INCIDENT_LEVEL,
+        required=False,
+    )
+
+    def _tristate(self, onkey, offkey):
+        on = self.cleaned_data.get(onkey, None)
+        off = self.cleaned_data.get(offkey, None)
+        if on == off:
+            return None
+        if on and not off:
+            return True
+        if off and not on:
+            return False
+
+    def to_filterblob(self):
+        if not self.is_valid():
+            return {}
+
+        filterblob = {}
+
+        open = self._tristate("open", "closed")
+        if open is not None:
+            filterblob["open"] = open
+
+        acked = self._tristate("acked", "unacked")
+        if acked is not None:
+            filterblob["acked"] = acked
+
+        source = self.cleaned_data.get("source", [])
+        if source:
+            filterblob["sourceSystemIds"] = source
+
+        maxlevel = self.cleaned_data.get("maxlevel", 0)
+        if maxlevel:
+            filterblob["maxlevel"] = maxlevel
+
+        return filterblob
+
+
+def incident_list_filter(request, qs):
+    # TODO: initialize with chosen Filter.filter if any
+    form = IncidentFilterForm(request.GET or None)
+
+    if form.is_valid():
+        filterblob = form.to_filterblob()
+        qs = QuerySetFilter.filtered_incidents(filterblob, qs)
+    return form, qs

--- a/src/argus_htmx/incidents/utils.py
+++ b/src/argus_htmx/incidents/utils.py
@@ -1,0 +1,15 @@
+import importlib
+
+from django.conf import settings
+
+FUNCTION_NAME = 'incident_list_filter'
+DEFAULT_MODULE = 'argus_htmx.incidents.filter'
+
+
+def get_filter_function():
+    dotted_path = getattr(settings, 'ARGUS_HTMX_FILTER_FUNCTION', DEFAULT_MODULE)
+    module = importlib.import_module(dotted_path)
+    function = getattr(module, FUNCTION_NAME, None)
+    if function:
+        return function
+    raise ImportError(f"Could not import {FUNCTION_NAME} from {dotted_path}")

--- a/src/argus_htmx/incidents/views.py
+++ b/src/argus_htmx/incidents/views.py
@@ -15,7 +15,7 @@ from argus.incident.models import Incident
 from argus.util.datetime_utils import make_aware
 
 from .customization import get_incident_table_columns
-from .filter import incident_list_filter
+from .utils import get_filter_function
 from .forms import AckForm
 
 
@@ -92,6 +92,7 @@ def incident_list(request: HtmxHttpRequest) -> HttpResponse:
     total_count = qs.count()
     last_refreshed = make_aware(datetime.now())
 
+    incident_list_filter = get_filter_function()
     filter_form, qs = incident_list_filter(request, qs)
     filtered_count = qs.count()
 

--- a/src/argus_htmx/templates/htmx/incidents/_incident_filterbox.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_filterbox.html
@@ -1,0 +1,6 @@
+<form>
+  <fieldset>
+  {{ filter_form }}
+  <input type="submit" value="Filter">
+  </fieldset>
+</form>

--- a/src/argus_htmx/templates/htmx/incidents/incident_list.html
+++ b/src/argus_htmx/templates/htmx/incidents/incident_list.html
@@ -1,6 +1,10 @@
 {% extends base %}
 
 {% block main %}
+    <section class="filterbox">
+      {% include "htmx/incidents/_incident_filterbox.html" %}
+    </section>
+
     <section>
         {% block table %}
             {% include "htmx/incidents/_incident_table.html" %}
@@ -8,10 +12,15 @@
     </section>
 
     <section>
-        <p>
-            Total, all time: {{ count }}
-        </p>
-        
+        <dl>
+          <dt>Total, all time</dt>
+          <dd> {{ count }}</dd>
+          <dt>After filtering</dt>
+          <dd> {{ filtered_count }}</dd>
+          <dt>Per page</Dt>
+          <dd>{{ per_page }}</dd>
+        </dl>
+
         {% block refresh_info %}
             {% include "htmx/incidents/_incidents_refresh_info.html" %}
         {% endblock refresh_info %}


### PR DESCRIPTION
How to swap out the box:

Set the setting "ARGUS_HTMX_FILTER_FUNCTION" to the dotted path of a module that contains the function "incident_list_filter", see argus_htmx/incidents/filter.py for signature.

You might then not need to replace the template: htmx/incidents/_incident_filterbox.html

(Replacing the template *will* be necessary to make things pretty.)