### PR TITLE
keep query params when reloading incidents list through htmx

### DIFF
--- a/src/argus_htmx/incidents/views.py
+++ b/src/argus_htmx/incidents/views.py
@@ -90,10 +90,11 @@ def incident_list(request: HtmxHttpRequest) -> HttpResponse:
     qs = prefetch_incident_daughters().order_by("-start_time")
     last_refreshed = make_aware(datetime.now())
 
-    # Standard Django pagination
-    page_num = request.GET.get("page", "1")
-    page = Paginator(object_list=qs, per_page=10).get_page(page_num)
+    params = dict(request.GET.items())
 
+    # Standard Django pagination
+    page_num = params.pop("page", "1")
+    page = Paginator(object_list=qs, per_page=10).get_page(page_num)
     # The htmx magic - use a different, minimal base template for htmx
     # requests, allowing us to skip rendering the unchanging parts of the
     # template.
@@ -113,6 +114,7 @@ def incident_list(request: HtmxHttpRequest) -> HttpResponse:
         "page": page,
         "last_refreshed": last_refreshed,
         "update_interval": 30,
+        "query_params": "&".join(f"{k}={v}" for k, v in params.items()),
     }
 
     return render(request, "htmx/incidents/incident_list.html", context=context)

--- a/src/argus_htmx/templates/htmx/incidents/_incident_table.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_table.html
@@ -1,5 +1,5 @@
 <table id="table"
-       hx-get="?page={{ page.number }}"
+       hx-get="?page={{ page.number }}&{{ query_params }}"
        hx-target="#table-body"
        hx-swap="innerHTML"
        hx-trigger="every {{ update_interval|default:'30' }}s"
@@ -47,15 +47,15 @@
                               page works without JavaScript, and to ensure the link is
                               displayed as clickable.
                             -->
-                            <a hx-get="?page=1" href="?page=1">
+                            <a hx-get="?page=1&{{ query_params }}" href="?page=1&{{ query_params }}">
                                 &laquo; First
                             </a>
                         </li>
                     {% endif %}
                     {% if page.has_previous %}
                         <li>
-                            <a hx-get="?page={{ page.previous_page_number }}"
-                               href="?page={{ page.previous_page_number }}">
+                            <a hx-get="?page={{ page.previous_page_number }}&{{ query_params }}"
+                               href="?page={{ page.previous_page_number }}&{{ query_params }}">
                                 {{ page.previous_page_number }}
                             </a>
                         </li>
@@ -65,16 +65,16 @@
                     </li>
                     {% if page.has_next %}
                         <li>
-                            <a hx-get="?page={{ page.next_page_number }}"
-                               href="?page={{ page.next_page_number }}">
+                            <a hx-get="?page={{ page.next_page_number }}&{{ query_params }}"
+                               href="?page={{ page.next_page_number }}&{{ query_params }}">
                                 {{ page.next_page_number }}
                             </a>
                         </li>
                     {% endif %}
                     {% if page.number != page.paginator.num_pages %}
                         <li>
-                            <a hx-get="?page={{ page.paginator.num_pages }}"
-                               href="?page={{ page.paginator.num_pages }}">
+                            <a hx-get="?page={{ page.paginator.num_pages }}&{{ query_params }}"
+                               href="?page={{ page.paginator.num_pages }}&{{ query_params }}">
                                 &raquo; Last
                             </a>
                         </li>


### PR DESCRIPTION
playing with #38 I noticed that filter parameters were reset when either autorefreshing the incident list or when changing the page. This MR fixes that by copying over all existing query params (except page) when reloading.