### PR TITLE
Overridable navbar links

### DIFF
--- a/src/argus_htmx/templates/htmx/base.html
+++ b/src/argus_htmx/templates/htmx/base.html
@@ -16,9 +16,11 @@
             </div>
             <div class="navbar-center flex">
                 <ul class="menu menu-horizontal px-1">
-                    <li><a href="{% url 'htmx:incident-list' %}">Incidents</a></li>
-                    <li><a href="{% url 'htmx:timeslot-placeholder' %}">Timeslots</a></li>
-                    <li><a href="{% url 'htmx:notificationprofile-placeholder' %}">Profiles</a></li>
+                    {% block navlinks %}
+                        <li><a href="{% url 'htmx:incident-list' %}">Incidents</a></li>
+                        <li><a href="{% url 'htmx:timeslot-placeholder' %}">Timeslots</a></li>
+                        <li><a href="{% url 'htmx:notificationprofile-placeholder' %}">Profiles</a></li>
+                    {% endblock navlinks %}
                 </ul>
             </div>
             <div class="navbar-end">


### PR DESCRIPTION
We'd like to be able to override navbar links but the current links are hard coded. This PR adds a block `navlinks` in `htmx/base.html` template to allow customization

I've based this PR on #43 since that PR has the latest version of `htmx/base.html`