### PR TITLE
Fix filterbox text input border

### DIFF
--- a/src/argus_htmx/templates/htmx/incidents/_incident_filterbox.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_filterbox.html
@@ -21,7 +21,7 @@
                         {% elif field|field_type == "multiplechoicefield" %}
                             {{ field|attr:"size:1"|add_class:"select select-accent border" }}
                         {% elif field|field_type == "charfield" %}
-                            {{ field|add_class:"input input-accent input-bordered" }}
+                            {{ field|add_class:"input input-accent input-bordered border" }}
                         {% endif %}
                     </label>
                 </li>


### PR DESCRIPTION
Adding the border class makes input field respect default border width