### PR TITLE
Allow logo customization through context

### DIFF
--- a/src/argus_htmx/templates/htmx/base.html
+++ b/src/argus_htmx/templates/htmx/base.html
@@ -13,9 +13,13 @@
     <header class="bg-neutral text-neutral-content">
         <nav class="navbar">
             <div class="navbar-start">
-                <a class="link" href="{% url 'htmx:incident-list' %}">
-                    <img class="object-scale-down h-14" src="{% static "logo_white.svg" %}" alt="go to homepage">
-                </a>
+                {% block logo %}
+                    <a class="link" href="{% url logo.url|default:'htmx:incident-list' %}">
+                        <img class="object-scale-down h-14"
+                             src="{% static logo.file|default:'logo_white.svg' %}"
+                             alt="{{ logo.alt|default:'go to homepage' }}">
+                    </a>
+                {% endblock logo %}
             </div>
             <div class="navbar-center flex">
                 <ul class="menu menu-horizontal px-1">


### PR DESCRIPTION
Allows for overriding the navbar logo with a custom logo through context variables. A developer may for example create
a context processor to change the logo and its associated properties:

```python
def logo(request):
    return {
        "logo": {
            "file": "logo_color.png",
            "alt": "geant-argus",
            "url": "home",
        }
    }
```