### PR TITLE
Support extra widget through context processor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -250,3 +250,5 @@ injects a ``incidents_extra_widget`` variable that points to a html template::
         return {
             "incidents_extra_widget": "path/to/_extra_widget.html",
         }
+
+*note* don't forget to include the context processor in your settings

--- a/README.rst
+++ b/README.rst
@@ -228,6 +228,14 @@ example::
 
     ]
 
+Then you could create ``/path/to/template.html`` as following::
+
+    <div id="service-status"
+         class="border border-primary rounded-2xl h-full p-2"
+         >
+      My custom widget
+    </div>
+
 For inbuilt support for other types of columns see the howtos in `the local docs <docs/howtos/>`_.
 
 

--- a/README.rst
+++ b/README.rst
@@ -230,9 +230,7 @@ example::
 
 Then you could create ``/path/to/template.html`` as following::
 
-    <div id="service-status"
-         class="border border-primary rounded-2xl h-full p-2"
-         >
+    <div id="service-status" class="border border-primary rounded-2xl h-full p-2">
       My custom widget
     </div>
 

--- a/README.rst
+++ b/README.rst
@@ -238,3 +238,15 @@ For inbuilt support for other types of columns see the howtos in `the local docs
 .. _list of daisyUI color names: https://daisyui.com/docs/colors/#-2
 .. _tailwind-cli-extra: https://github.com/dobicinaitis/tailwind-cli-extra
 .. _Tailwind CSS theme customization: https://tailwindcss.com/docs/theme
+
+Custom widget
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Argus supports showing an extra widget next to the menubar in the incidents listing. This box can
+take the width of 1/3 of the window. You can add widget by creating a context processor that
+injects a ``incidents_extra_widget`` variable that points to a html template::
+
+    def extra_widget(request):
+        return {
+            "incidents_extra_widget": "path/to/_extra_widget.html",
+        }

--- a/README.rst
+++ b/README.rst
@@ -228,12 +228,6 @@ example::
 
     ]
 
-Then you could create ``/path/to/template.html`` as following::
-
-    <div id="service-status" class="border border-primary rounded-2xl h-full p-2">
-      My custom widget
-    </div>
-
 For inbuilt support for other types of columns see the howtos in `the local docs <docs/howtos/>`_.
 
 
@@ -258,3 +252,9 @@ injects a ``incidents_extra_widget`` variable that points to a html template::
         }
 
 *note* don't forget to include the context processor in your settings
+
+You could then create ``path/to/_extra_widget.html`` as following::
+
+    <div id="service-status" class="border border-primary rounded-2xl h-full p-2">
+      My custom widget
+    </div>

--- a/src/argus_htmx/templates/htmx/incidents/incident_list.html
+++ b/src/argus_htmx/templates/htmx/incidents/incident_list.html
@@ -2,7 +2,14 @@
 
 {% block main %}
     <section>
-        {% include "htmx/incidents/_incidents_menubar.html" %}
+        {% if incidents_extra_widget %}
+        <div class="flex">
+            <div class="w-2/3">{% include "htmx/incidents/_incidents_menubar.html" %}</div>
+            <div class="w-1/3 ml-2">{% include incidents_extra_widget %}</div>
+        </div>
+        {% else %}
+            {% include "htmx/incidents/_incidents_menubar.html" %}
+        {% endif %}
     </section>
 
     <section class="overflow-x-auto">


### PR DESCRIPTION
Supports adding a widget to the incident listing through settting the `incidents_extra_widget` context variable to a template path that will then be included next to the menu bar. The widget will take up 1/3 of the width.