### PR TITLE
Make modal for add/edit ticket url work in details view

### DIFF
--- a/src/argus_htmx/incidents/forms.py
+++ b/src/argus_htmx/incidents/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 
+
 class AckForm(forms.Form):
     description = forms.CharField()
     expiration = forms.DateTimeField(required=False)
@@ -8,3 +9,11 @@ class AckForm(forms.Form):
 class DescriptionOptionalForm(forms.Form):
     "For closing/reopening"
     description = forms.CharField(required=False)
+
+
+class EditTicketUrlForm(forms.Form):
+    ticket_url = forms.URLField(required=False)
+
+
+class AddTicketUrlForm(forms.Form):
+    ticket_url = forms.URLField(required=True)

--- a/src/argus_htmx/incidents/urls.py
+++ b/src/argus_htmx/incidents/urls.py
@@ -11,4 +11,6 @@ urlpatterns = [
     path("<int:pk>/ack-detail/", views.incident_detail_add_ack, name="incident-detail-add-ack"),
     path("<int:pk>/close-detail/", views.incident_detail_close, name="incident-detail-close"),
     path("<int:pk>/reopen-detail/", views.incident_detail_reopen, name="incident-detail-reopen"),
+    path("<int:pk>/ticket-edit-detail/", views.incident_detail_edit_ticket, name="incident-detail-edit-ticket"),
+    path("<int:pk>/ticket-add-detail/", views.incident_detail_add_ticket, name="incident-detail-add-ticket"),
 ]

--- a/src/argus_htmx/incidents/views.py
+++ b/src/argus_htmx/incidents/views.py
@@ -21,7 +21,7 @@ from argus.util.datetime_utils import make_aware
 
 from .customization import get_incident_table_columns
 from .utils import get_filter_function
-from .forms import AckForm, DescriptionOptionalForm
+from .forms import AckForm, DescriptionOptionalForm, EditTicketUrlForm, AddTicketUrlForm
 
 
 User = get_user_model()
@@ -60,6 +60,8 @@ def incident_detail(request, pk: int):
         "ack": reverse("htmx:incident-detail-add-ack", kwargs={"pk": pk}),
         "close": reverse("htmx:incident-detail-close", kwargs={"pk": pk}),
         "reopen": reverse("htmx:incident-detail-reopen", kwargs={"pk": pk}),
+        "edit_ticket": reverse("htmx:incident-detail-edit-ticket", kwargs={"pk": pk}),
+        "add_ticket": reverse("htmx:incident-detail-add-ticket", kwargs={"pk": pk}),
     }
     context = {
         "incident": incident,
@@ -140,6 +142,32 @@ def incident_detail_reopen(request, pk: int):
             description=form.cleaned_data.get("description", ""),
         )
         LOG.info(f"{{ incident }} manually reopened by {{ request.user }}")
+    return redirect("htmx:incident-detail", pk=pk)
+
+
+@require_POST
+def incident_detail_add_ticket(request, pk: int):
+    incident = get_object_or_404(Incident, id=pk)
+    form = AddTicketUrlForm()
+    if request.POST:
+        form = AddTicketUrlForm(request.POST)
+        if form.is_valid():
+            incident.ticket_url = form.cleaned_data["ticket_url"]
+            incident.save()
+
+    return redirect("htmx:incident-detail", pk=pk)
+
+
+@require_POST
+def incident_detail_edit_ticket(request, pk: int):
+    incident = get_object_or_404(Incident, id=pk)
+    form = EditTicketUrlForm()
+    if request.POST:
+        form = EditTicketUrlForm(request.POST)
+        if form.is_valid():
+            incident.ticket_url = form.cleaned_data["ticket_url"]
+            incident.save()
+
     return redirect("htmx:incident-detail", pk=pk)
 
 

--- a/src/argus_htmx/templates/htmx/incidents/_incident_ticket_edit_modal.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_ticket_edit_modal.html
@@ -1,4 +1,6 @@
 {% extends 'htmx/_base_form_modal.html' %}
 {% block dialogform %}
-<input id="ticket_url" value={{ incident.ticket_url|default:"" }}" />
+<label>Ticket url
+    <input name="ticket_url" value="{{ incident.ticket_url|default:'' }}" placeholder="Ticket url" class="input input-bordered w-full max-w-xs" />
+</label>
 {% endblock dialogform %}

--- a/src/argus_htmx/templates/htmx/incidents/_incident_ticket_manual_create_modal.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_ticket_manual_create_modal.html
@@ -1,0 +1,6 @@
+{% extends 'htmx/_base_form_modal.html' %}
+{% block dialogform %}
+<label>Ticket url
+   <input name="ticket_url" required placeholder="Ticket url" class="input input-bordered w-full max-w-xs"/>
+</label>
+{% endblock dialogform %}

--- a/src/argus_htmx/templates/htmx/incidents/incident_detail.html
+++ b/src/argus_htmx/templates/htmx/incidents/incident_detail.html
@@ -79,9 +79,10 @@
 {% endif %}
 
 {% if incident.ticket_url %}
-{% include 'htmx/incidents/_incident_ticket_edit_modal.html' with dialog_id="edit-ticket-dialog" button_title="Edit ticket url" header="Edit ticket" explanation="" cancel_text="Cancel" submit_text="Update" %}
+{% include 'htmx/incidents/_incident_ticket_edit_modal.html' with dialog_id="edit-ticket-dialog" button_title="Edit ticket url" header="Edit ticket" explanation="" endpoint=endpoints.edit_ticket cancel_text="Cancel" submit_text="Update" %}
 {% else %}
-{% include 'htmx/incidents/_incident_ticket_autocreate_modal.html' with dialog_id="create-ticket-dialog" button_title="Create ticket url" header="Create ticket" explanation="Are you sure you want to automatically generate a ticket from this incident?" cancel_text="No" submit_text="Yes" %}
+<!-- Manually create ticket dialog -->
+{% include 'htmx/incidents/_incident_ticket_edit_modal.html' with dialog_id="manual-create-ticket-dialog" button_title="Add ticket url" header="Add url to existing ticket" explanation="Are you sure you want to store this url to an existing ticket on this incident?" endpoint=endpoints.add_ticket cancel_text="Cancel" submit_text="Add ticket" %}
 {% endif %}
 
 </div>


### PR DESCRIPTION
Closes #124 as well, at least on Firefox.

This does not handle autocreation of tickets. 

We must settle on how to report the many possible errors from the ticket plugin before we can support autocreation of tickets.