### PR TITLE
Show full event type name in incident detail

### DIFF
--- a/src/argus_htmx/templates/htmx/incidents/incident_detail.html
+++ b/src/argus_htmx/templates/htmx/incidents/incident_detail.html
@@ -119,7 +119,7 @@
 {% if not event.ack %}
 <div class="card-body flex-none">
 <p>
-{{ event.type }}
+{{ event.get_type_display }}
 </p>
 <p>
 {{ event.description }}


### PR DESCRIPTION
Closes #111.

![image](https://github.com/user-attachments/assets/df65b5eb-f78a-46ca-bcc1-d06fca8783d8)
