### PR TITLE
Show "Ticket" instead of "Acknowledged" in status block of details page

### DIFF
--- a/src/argus_htmx/templates/htmx/incidents/incident_detail.html
+++ b/src/argus_htmx/templates/htmx/incidents/incident_detail.html
@@ -25,7 +25,7 @@
 <span class="badge badge-primary">Acknowledged</span>{% else %}
 <span class="badge badge-accent">Unanacknowledged</span>{% endif %}
 {% if incident.ticket_url %}
-<span class="badge badge-primary"><a href="{{ incident.ticket_url }}">Ticket {{ incident.ticket_url }}</a></span>{% else %}
+<span class="badge badge-primary"><a href="{{ incident.ticket_url }}" target="_blank">Ticket {{ incident.ticket_url }}</a></span>{% else %}
 <span class="badge badge-accent">No ticket</span>{% endif %}
 </p>
 </section>

--- a/src/argus_htmx/templates/htmx/incidents/incident_detail.html
+++ b/src/argus_htmx/templates/htmx/incidents/incident_detail.html
@@ -25,7 +25,7 @@
 <span class="badge badge-primary">Acknowledged</span>{% else %}
 <span class="badge badge-accent">Unanacknowledged</span>{% endif %}
 {% if incident.ticket_url %}
-<span class="badge badge-primary">Acknowledged</span>{% else %}
+<span class="badge badge-primary">Ticket</span>{% else %}
 <span class="badge badge-accent">No ticket</span>{% endif %}
 </p>
 </section>

--- a/src/argus_htmx/templates/htmx/incidents/incident_detail.html
+++ b/src/argus_htmx/templates/htmx/incidents/incident_detail.html
@@ -25,7 +25,7 @@
 <span class="badge badge-primary">Acknowledged</span>{% else %}
 <span class="badge badge-accent">Unanacknowledged</span>{% endif %}
 {% if incident.ticket_url %}
-<span class="badge badge-primary">Ticket</span>{% else %}
+<span class="badge badge-primary"><a href="{{ incident.ticket_url }}">Ticket {{ incident.ticket_url }}</a></span>{% else %}
 <span class="badge badge-accent">No ticket</span>{% endif %}
 </p>
 </section>


### PR DESCRIPTION
Closes #128. 

Open for discussion about which of the commits to merge - in the first two commits I made it look like the original Argus-frontend and in the third I added that clicking the link will open it in another tab. 