### PR TITLE
Add linting of CSS and HTML files using MegaLinter

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Reformat html files using djLint @johannaengland 12/09/2024
+c53dafbd8632f101d960a67d950245e4bb42f21e

--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -1,0 +1,44 @@
+# MegaLinter GitHub Action configuration file
+# More info at https://megalinter.io
+name: MegaLinter
+on:
+  push:
+    branches: main
+  pull_request:
+
+jobs:
+  megalinter:
+    name: MegaLinter
+    runs-on: ubuntu-latest
+    permissions:
+      # Give the linter write permission to comment on PRs (if PR is not from fork)
+      issues: write
+      pull-requests: write
+    steps:
+      # Git Checkout
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+      # MegaLinter
+      - name: MegaLinter
+        id: ml
+        # You can override MegaLinter flavor used to have faster performances
+        # More info at https://megalinter.io/flavors/
+        uses: oxsecurity/megalinter/flavors/python@v8
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Validate whole codebase on pushes and only changes on pull requests
+          # VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push'}}
+          VALIDATE_ALL_CODEBASE: true
+
+      # Upload MegaLinter artifacts
+      - name: Archive production artifacts
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: MegaLinter reports
+          path: |
+            megalinter-reports
+            mega-linter.log

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ src/argus_htmx/tailwindtheme/tailwindcss
 
 !.gitattributes
 !.gitignore
+!.git-blame-ignore-revs
 !.pre-commit-config.yaml
 !.mega-linter.yml
 !.github

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ src/argus_htmx/tailwindtheme/tailwindcss
 !.gitattributes
 !.gitignore
 !.pre-commit-config.yaml
+!.mega-linter.yml
+!.github

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,0 +1,12 @@
+# All available variables are described in documentation
+# https://megalinter.io/configuration/
+
+LINTER_RULES_PATH: .
+
+ENABLE_LINTERS:
+  - HTML_DJLINT
+
+# Make workflow fail even on non blocking errors
+FORMATTERS_DISABLE_ERRORS: false
+
+HTML_DJLINT_ARGUMENTS: "--lint --check"

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -5,8 +5,11 @@ LINTER_RULES_PATH: .
 
 ENABLE_LINTERS:
   - HTML_DJLINT
+  - CSS_STYLELINT
 
 # Make workflow fail even on non blocking errors
 FORMATTERS_DISABLE_ERRORS: false
 
 HTML_DJLINT_ARGUMENTS: "--lint --check"
+
+CSS_STYLELINT_CONFIG_FILE: stylelint.config.js

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,8 @@ repos:
     hooks:
     -   id: djlint-reformat
     -   id: djlint
+
+-   repo: https://github.com/thibaudcolas/pre-commit-stylelint
+    rev: v14.4.0
+    hooks:
+    -   id: stylelint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,9 @@ repos:
         name: "Flake8: critical"
         args: ['--count', '--select=E9,F63,F7,F82', '--show-source', '--statistics']
         types: [file, python]
+
+-   repo: https://github.com/djlint/djLint
+    rev: v1.35.2
+    hooks:
+    -   id: djlint-reformat
+    -   id: djlint

--- a/src/argus_htmx/templates/htmx/_base_form_modal.html
+++ b/src/argus_htmx/templates/htmx/_base_form_modal.html
@@ -1,12 +1,13 @@
-<button class="btn"
-        onclick="htmx.find('#{{ dialog_id }}').showModal()"
->
-    {{ button_title }}
-</button>
+<button class="btn" onclick="htmx.find('#{{ dialog_id }}').showModal()">{{ button_title }}</button>
 <dialog id="{{ dialog_id }}" class="modal">
     <div class="modal-box card card-compact shadow-xl">
-        <div class="divider divider-start"><h3 class="card-title">{{ header }}</h3></div>
-        <form id="{{ dialog_id }}-form" class="card-body" method="post" action="{{ endpoint }}">
+        <div class="divider divider-start">
+            <h3 class="card-title">{{ header }}</h3>
+        </div>
+        <form id="{{ dialog_id }}-form"
+              class="card-body"
+              method="post"
+              action="{{ endpoint }}">
             {% csrf_token %}
             <fieldset class="menu menu-vertical gap-4">
                 <legend class="antialiased text-base font-bold py-2">{{ explanation }}</legend>
@@ -17,8 +18,7 @@
         <div class="modal-action card-actions">
             <form method="dialog" class="w-full">
                 <div class="divider divider-end">
-                    <button type="submit" form="{{ dialog_id }}-form"
-                            class="btn btn-primary">{{ submit_text }}</button>
+                    <button type="submit" form="{{ dialog_id }}-form" class="btn btn-primary">{{ submit_text }}</button>
                     <button class="btn">{{ cancel_text }}</button>
                 </div>
             </form>

--- a/src/argus_htmx/templates/htmx/base.html
+++ b/src/argus_htmx/templates/htmx/base.html
@@ -1,6 +1,5 @@
 {% extends "htmx_base.html" %}
 {% load static %}
-
 {% block header %}
     <header class="bg-neutral text-neutral-content">
         <nav class="navbar">
@@ -16,9 +15,15 @@
             <div class="navbar-center flex">
                 <ul class="menu menu-horizontal px-1">
                     {% block navlinks %}
-                        <li><a href="{% url 'htmx:incident-list' %}">Incidents</a></li>
-                        <li><a href="{% url 'htmx:timeslot-placeholder' %}">Timeslots</a></li>
-                        <li><a href="{% url 'htmx:notificationprofile-placeholder' %}">Profiles</a></li>
+                        <li>
+                            <a href="{% url 'htmx:incident-list' %}">Incidents</a>
+                        </li>
+                        <li>
+                            <a href="{% url 'htmx:timeslot-placeholder' %}">Timeslots</a>
+                        </li>
+                        <li>
+                            <a href="{% url 'htmx:notificationprofile-placeholder' %}">Profiles</a>
+                        </li>
                     {% endblock navlinks %}
                 </ul>
             </div>
@@ -38,9 +43,7 @@
                                     Logged in as: <span class="text-info">{{ request.user }}</span>
                                     <div class="divider divider-secondary my-0"></div>
                                 </li>
-                                <li>
-                                    {% include 'htmx/themes/theme_dropdown.html' %}
-                                </li>
+                                <li>{% include 'htmx/themes/theme_dropdown.html' %}</li>
                                 <li>
                                     <form class="flex" action="{% url "htmx:logout" %}" method="POST">
                                         {% csrf_token %}

--- a/src/argus_htmx/templates/htmx/incidents/_incident_ack.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_ack.html
@@ -1,4 +1,7 @@
 <a class="link" href="{% url 'htmx:incident-add-ack' pk=incident.pk %}">
-	{% if incident.acked %}<span class="badge badge-primary">Acked</span>
-	{% else %}<span class="badge badge-accent">Unacked</span>{% endif %}
+    {% if incident.acked %}
+        <span class="badge badge-primary">Acked</span>
+    {% else %}
+        <span class="badge badge-accent">Unacked</span>
+    {% endif %}
 </a>

--- a/src/argus_htmx/templates/htmx/incidents/_incident_acknowledge_modal.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_acknowledge_modal.html
@@ -1,11 +1,19 @@
 {% extends 'htmx/_base_form_modal.html' %}
 {% block dialogform %}
-    <label class="indicator input input-bordered flex items-center gap-2 w-full">Message
+    <label class="indicator input input-bordered flex items-center gap-2 w-full">
+        Message
         <span class="indicator-item indicator-top indicator-start badge border-none mask mask-circle text-warning text-base">＊</span>
-        <input name="description" type="text" placeholder="Acknowledgment message" required
-               class="appearance-none grow border-none"/>
+        <input name="description"
+               type="text"
+               placeholder="Acknowledgment message"
+               required
+               class="appearance-none grow border-none" />
     </label>
-    <label class="input input-bordered flex items-center gap-2 w-full">Expiration
-        <input name="expiration" type="date" placeholder="Expiry date" class="appearance-none grow border-none"/>
+    <label class="input input-bordered flex items-center gap-2 w-full">
+        Expiration
+        <input name="expiration"
+               type="date"
+               placeholder="Expiry date"
+               class="appearance-none grow border-none" />
     </label>
 {% endblock dialogform %}

--- a/src/argus_htmx/templates/htmx/incidents/_incident_checkbox.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_checkbox.html
@@ -1,7 +1,6 @@
 <label for="select-incident-{{ incident.pk }}" class="sr-only">Select all visible</label>
-<input id="select-incident-{{ incident.pk }}" 
-       hx-preserve 
-       type="checkbox" 
+<input id="select-incident-{{ incident.pk }}"
+       hx-preserve
+       type="checkbox"
        class="row-select checkbox checkbox-sm checkbox-accent border"
-       hx-on:change="event.target.checked ? htmx.find('.tab-select').checked = event.target.checked : null;"
->
+       hx-on:change="event.target.checked ? htmx.find('.tab-select').checked = event.target.checked : null;">

--- a/src/argus_htmx/templates/htmx/incidents/_incident_close_modal.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_close_modal.html
@@ -1,6 +1,10 @@
 {% extends 'htmx/_base_form_modal.html' %}
 {% block dialogform %}
-<label>Reason for closing
-  <input name="description" type="text" placeholder="Closing message" class="input input-bordered w-full max-w-xs" />
-</label>
+    <label>
+        Reason for closing
+        <input name="description"
+               type="text"
+               placeholder="Closing message"
+               class="input input-bordered w-full max-w-xs" />
+    </label>
 {% endblock dialogform %}

--- a/src/argus_htmx/templates/htmx/incidents/_incident_combined_status.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_combined_status.html
@@ -1,6 +1,12 @@
-{% if incident.open %}<span class="badge badge-primary">Open</span>
-{% else %}<span class="badge badge-accent">Closed</span>{% endif %}
+{% if incident.open %}
+    <span class="badge badge-primary">Open</span>
+{% else %}
+    <span class="badge badge-accent">Closed</span>
+{% endif %}
 <a class="link" href="{% url 'htmx:incident-add-ack' pk=incident.pk %}">
-{% if incident.acked %}<span class="badge badge-primary">Acked</span>
-{% else %}<span class="badge badge-accent">Unacked</span>{% endif %}
+    {% if incident.acked %}
+        <span class="badge badge-primary">Acked</span>
+    {% else %}
+        <span class="badge badge-accent">Unacked</span>
+    {% endif %}
 </a>

--- a/src/argus_htmx/templates/htmx/incidents/_incident_filterbox.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_filterbox.html
@@ -1,13 +1,11 @@
 {% load widget_tweaks %}
 <form>
-    <fieldset
-            hx-get="{% url 'htmx:incident-list' %}"
-            hx-include="this"
-            hx-trigger="change delay:100ms"
-            hx-target="#table"
-            hx-swap="outerHTML"
-            hx-push-url="true"
-    >
+    <fieldset hx-get="{% url 'htmx:incident-list' %}"
+              hx-include="this"
+              hx-trigger="change delay:100ms"
+              hx-target="#table"
+              hx-swap="outerHTML"
+              hx-push-url="true">
         <legend class="sr-only">Filter incidents</legend>
         <ul class="menu menu-horizontal menu-sm flex items-center gap-2 py-1.5">
             {% for field in filter_form %}
@@ -20,9 +18,7 @@
                             <div>
                                 {{ field|add_class:"range range-primary range-xs" }}
                                 <div class="flex w-full justify-between px-2 text-xs">
-                                    {% for tick in "12345" %}
-                                    <span>{{ tick }}</span>
-                                    {% endfor %}
+                                    {% for tick in "12345" %}<span>{{ tick }}</span>{% endfor %}
                                 </div>
                             </div>
                         {% elif field|field_type == "choicefield" %}
@@ -35,11 +31,8 @@
                     </label>
                 </li>
             {% empty %}
-                <li>
-                    No filter fields configured
-                </li>
+                <li>No filter fields configured</li>
             {% endfor %}
         </ul>
-
     </fieldset>
 </form>

--- a/src/argus_htmx/templates/htmx/incidents/_incident_reopen_modal.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_reopen_modal.html
@@ -1,6 +1,10 @@
 {% extends 'htmx/_base_form_modal.html' %}
 {% block dialogform %}
-<label>Reason for reopening
-  <input name="description" type="text" placeholder="Reopening message" class="input input-bordered w-full max-w-xs" />
-</label>
+    <label>
+        Reason for reopening
+        <input name="description"
+               type="text"
+               placeholder="Reopening message"
+               class="input input-bordered w-full max-w-xs" />
+    </label>
 {% endblock dialogform %}

--- a/src/argus_htmx/templates/htmx/incidents/_incident_row.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_row.html
@@ -1,21 +1,21 @@
-  <li>
-	  HTMX-app
-	  {% block incident_pk %}
-	  {% include "htmx/incidents/_incident_pk.html" %}
-	  {% endblock %}
-	  {% block status %}
-	  {% include "htmx/incidents/_incident_status.html" %}
-	  {% endblock %}
-	  {% block acknowledgement %}
-	  {% include "htmx/incidents/_incident_ack.html" %}
-	  {% endblock %}
-	  {% block tag %}
-	  {% include "htmx/incidents/_incident_tag.html" with tag="location" %}
-	  {% endblock %}
-	  {% block start_time %}
-	  {% include "htmx/incidents/_incident_start_time.html" %}
-	  {% endblock %}
-	  {% block description %}
-	  {% include "htmx/incidents/_incident_description.html" %}
-	  {% endblock %}
-  </li>
+<li>
+    HTMX-app
+    {% block incident_pk %}
+        {% include "htmx/incidents/_incident_pk.html" %}
+    {% endblock %}
+    {% block status %}
+        {% include "htmx/incidents/_incident_status.html" %}
+    {% endblock %}
+    {% block acknowledgement %}
+        {% include "htmx/incidents/_incident_ack.html" %}
+    {% endblock %}
+    {% block tag %}
+        {% include "htmx/incidents/_incident_tag.html" with tag="location" %}
+    {% endblock %}
+    {% block start_time %}
+        {% include "htmx/incidents/_incident_start_time.html" %}
+    {% endblock %}
+    {% block description %}
+        {% include "htmx/incidents/_incident_description.html" %}
+    {% endblock %}
+</li>

--- a/src/argus_htmx/templates/htmx/incidents/_incident_status.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_status.html
@@ -1,2 +1,5 @@
-{% if incident.open %}<span class="badge badge-primary">Open</span>
-{% else %}<span class="badge badge-accent">Closed</span>{% endif %}
+{% if incident.open %}
+    <span class="badge badge-primary">Open</span>
+{% else %}
+    <span class="badge badge-accent">Closed</span>
+{% endif %}

--- a/src/argus_htmx/templates/htmx/incidents/_incident_table.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_table.html
@@ -5,43 +5,37 @@
        hx-trigger="every {{ update_interval|default:'30' }}s"
        hx-push-url="true"
        hx-include=".filterbox fieldset"
-       class="border border-separate border-spacing-1 border-primary table"
->
+       class="border border-separate border-spacing-1 border-primary table">
     <thead>
-    <tr class="border-b border-primary">
-        {% block columns %}
-            {% for col in columns %}
-                <th class="border-b border-primary">
-                    {% if col.header_template %}
-                        {% include col.header_template with label=col.label %}
-                    {% else %}
-                        {{ col.label }}
-                    {% endif %}
-                </th>
-            {% empty %}
-                <th class="border-b border-primary">
-                    No columns configured
-                </th>
-            {% endfor %}
-        {% endblock columns %}
-    </tr>
+        <tr class="border-b border-primary">
+            {% block columns %}
+                {% for col in columns %}
+                    <th class="border-b border-primary">
+                        {% if col.header_template %}
+                            {% include col.header_template with label=col.label %}
+                        {% else %}
+                            {{ col.label }}
+                        {% endif %}
+                    </th>
+                {% empty %}
+                    <th class="border-b border-primary">No columns configured</th>
+                {% endfor %}
+            {% endblock columns %}
+        </tr>
     </thead>
-    <tbody
-            id="table-body"
-            class=""
-    >
-    {% block incident_rows %}
-        {% include 'htmx/incidents/_incident_table_rows.html' with incident_list=page.object_list %}
-    {% endblock incident_rows %}
+    <tbody id="table-body" class="">
+        {% block incident_rows %}
+            {% include 'htmx/incidents/_incident_table_rows.html' with incident_list=page.object_list %}
+        {% endblock incident_rows %}
     </tbody>
     <tfoot>
-    <tr>
-        <td colspan="{{ columns|length }}" class="border-t border-primary">
-            <div class="flex justify-between items-center">
-                {% block refresh_info %}
-                    {% include "htmx/incidents/_incidents_refresh_info.html" %}
-                {% endblock refresh_info %}
-                <!--
+        <tr>
+            <td colspan="{{ columns|length }}" class="border-t border-primary">
+                <div class="flex justify-between items-center">
+                    {% block refresh_info %}
+                        {% include "htmx/incidents/_incidents_refresh_info.html" %}
+                    {% endblock refresh_info %}
+                    <!--
                 The htmx attributes set on the nav here are inherited by the child links.
                 hx-target tells where htmx to swap the fetched content in, and hx-swap
                 tells it how to swap it - by replacing the 'outerHTML' attribute of the
@@ -49,57 +43,54 @@
                 htmx to push the fetched URL into the browser history, so we can use
                 the backwards/forwards buttons to navigate these subpages.
                 -->
-                <ul class="join" hx-target="#table" hx-swap="outerHTML" hx-push-url="true">
-                    {% if page.number != 1 %}
-                        <li>
-                            <!--
+                    <ul class="join"
+                        hx-target="#table"
+                        hx-swap="outerHTML"
+                        hx-push-url="true">
+                        {% if page.number != 1 %}
+                            <li>
+                                <!--
                               For each link we use hx-get to tell htmx to fetch that URL and
                               swap it in. We also repeat the URL in the href attribute so the
                               page works without JavaScript, and to ensure the link is
                               displayed as clickable.
                             -->
-                            <a hx-get="?page=1" href="?page=1" class="join-item btn btn-neutral">
-                                &laquo; First
-                            </a>
-                        </li>
-                    {% endif %}
-                    {% if page.has_previous %}
-                        <li>
-                            <a hx-get="?page={{ page.previous_page_number }}"
-                               href="?page={{ page.previous_page_number }}" class="join-item btn btn-neutral">
-                                {{ page.previous_page_number }}
-                            </a>
-                        </li>
-                    {% endif %}
-                    {% if page.paginator.num_pages > 1 %}
-                        <li>
-                            <button class="join-item btn btn-active btn-neutral">{{ page.number }}</button>
-                        </li>
-                    {% else %}
-                        <li>
-                            <button class="btn btn-active btn-neutral">{{ page.number }}</button>
-                        </li>
-                    {% endif %}
-
-                    {% if page.has_next %}
-                        <li>
-                            <a hx-get="?page={{ page.next_page_number }}"
-                               href="?page={{ page.next_page_number }}" class="join-item btn btn-neutral">
-                                {{ page.next_page_number }}
-                            </a>
-                        </li>
-                    {% endif %}
-                    {% if page.number != page.paginator.num_pages %}
-                        <li>
-                            <a hx-get="?page={{ page.paginator.num_pages }}"
-                               href="?page={{ page.paginator.num_pages }}" class="join-item btn btn-neutral">
-                                &raquo; Last
-                            </a>
-                        </li>
-                    {% endif %}
-                </ul>
-            </div>
-        </td>
-    </tr>
+                                <a hx-get="?page=1" href="?page=1" class="join-item btn btn-neutral">&laquo; First</a>
+                            </li>
+                        {% endif %}
+                        {% if page.has_previous %}
+                            <li>
+                                <a hx-get="?page={{ page.previous_page_number }}"
+                                   href="?page={{ page.previous_page_number }}"
+                                   class="join-item btn btn-neutral">{{ page.previous_page_number }}</a>
+                            </li>
+                        {% endif %}
+                        {% if page.paginator.num_pages > 1 %}
+                            <li>
+                                <button class="join-item btn btn-active btn-neutral">{{ page.number }}</button>
+                            </li>
+                        {% else %}
+                            <li>
+                                <button class="btn btn-active btn-neutral">{{ page.number }}</button>
+                            </li>
+                        {% endif %}
+                        {% if page.has_next %}
+                            <li>
+                                <a hx-get="?page={{ page.next_page_number }}"
+                                   href="?page={{ page.next_page_number }}"
+                                   class="join-item btn btn-neutral">{{ page.next_page_number }}</a>
+                            </li>
+                        {% endif %}
+                        {% if page.number != page.paginator.num_pages %}
+                            <li>
+                                <a hx-get="?page={{ page.paginator.num_pages }}"
+                                   href="?page={{ page.paginator.num_pages }}"
+                                   class="join-item btn btn-neutral">&raquo; Last</a>
+                            </li>
+                        {% endif %}
+                    </ul>
+                </div>
+            </td>
+        </tr>
     </tfoot>
 </table>

--- a/src/argus_htmx/templates/htmx/incidents/_incident_table_rows.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_table_rows.html
@@ -2,10 +2,8 @@
     {% block incident %}
         {% include 'htmx/incidents/_incident_table_row.html' %}
     {% endblock incident %}
-    {% empty %}
+{% empty %}
     <tr>
-        <td colspan="{{ columns|length }}">
-            No incidents on this page.
-        </td>
+        <td colspan="{{ columns|length }}">No incidents on this page.</td>
     </tr>
 {% endfor %}

--- a/src/argus_htmx/templates/htmx/incidents/_incident_ticket.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_ticket.html
@@ -1,5 +1,11 @@
 {% if incident.ticket_url %}
-<a class="link" href="{{ incident.ticket_url }}" target="_blank">
-<svg class="size-5 fill-accent" focusable="false" viewBox="0 0 24 24" aria-hidden="true"><path d="M21.41 11.58l-9-9C12.05 2.22 11.55 2 11 2H4c-1.1 0-2 .9-2 2v7c0 .55.22 1.05.59 1.42l9 9c.36.36.86.58 1.41.58.55 0 1.05-.22 1.41-.59l7-7c.37-.36.59-.86.59-1.41 0-.55-.23-1.06-.59-1.42zM5.5 7C4.67 7 4 6.33 4 5.5S4.67 4 5.5 4 7 4.67 7 5.5 6.33 7 5.5 7z"></path></svg>
-</a>
+    <a class="link" href="{{ incident.ticket_url }}" target="_blank">
+        <svg class="size-5 fill-accent"
+             focusable="false"
+             viewBox="0 0 24 24"
+             aria-hidden="true">
+            <path d="M21.41 11.58l-9-9C12.05 2.22 11.55 2 11 2H4c-1.1 0-2 .9-2 2v7c0 .55.22 1.05.59 1.42l9 9c.36.36.86.58 1.41.58.55 0 1.05-.22 1.41-.59l7-7c.37-.36.59-.86.59-1.41 0-.55-.23-1.06-.59-1.42zM5.5 7C4.67 7 4 6.33 4 5.5S4.67 4 5.5 4 7 4.67 7 5.5 6.33 7 5.5 7z">
+            </path>
+        </svg>
+    </a>
 {% endif %}

--- a/src/argus_htmx/templates/htmx/incidents/_incident_ticket_edit_modal.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_ticket_edit_modal.html
@@ -1,6 +1,10 @@
 {% extends 'htmx/_base_form_modal.html' %}
 {% block dialogform %}
-<label>Ticket url
-    <input name="ticket_url" value="{{ incident.ticket_url|default:'' }}" placeholder="Ticket url" class="input input-bordered w-full max-w-xs" />
-</label>
+    <label>
+        Ticket url
+        <input name="ticket_url"
+               value="{{ incident.ticket_url|default:'' }}"
+               placeholder="Ticket url"
+               class="input input-bordered w-full max-w-xs" />
+    </label>
 {% endblock dialogform %}

--- a/src/argus_htmx/templates/htmx/incidents/_incident_ticket_manual_create_modal.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_ticket_manual_create_modal.html
@@ -1,6 +1,10 @@
 {% extends 'htmx/_base_form_modal.html' %}
 {% block dialogform %}
-<label>Ticket url
-   <input name="ticket_url" required placeholder="Ticket url" class="input input-bordered w-full max-w-xs"/>
-</label>
+    <label>
+        Ticket url
+        <input name="ticket_url"
+               required
+               placeholder="Ticket url"
+               class="input input-bordered w-full max-w-xs" />
+    </label>
 {% endblock dialogform %}

--- a/src/argus_htmx/templates/htmx/incidents/_incidents_menubar.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incidents_menubar.html
@@ -1,23 +1,20 @@
 <div role="tablist" class="tabs tabs-lifted">
     {% block menu_tabs %}
-        <input type="radio" 
-               name="incident_menus" 
+        <input type="radio"
+               name="incident_menus"
                role="tab"
                class="tab [--tab-border:theme(borderWidth.DEFAULT)] [--tab-border-color:theme(colors.primary)]"
                aria-label="Filter Incidents"
-               checked="checked"
-        />
+               checked="checked" />
         <div role="tabpanel"
              class="filterbox tab-content border-primary [--tab-border:theme(borderWidth.DEFAULT)] rounded-box p-2">
             {% include "htmx/incidents/_incident_filterbox.html" %}
         </div>
-        <input
-                type="radio"
-                name="incident_menus"
-                role="tab"
-                class="tab tab-select [--tab-border:theme(borderWidth.DEFAULT)] [--tab-border-color:theme(colors.primary)]"
-                aria-label="Update Incidents"
-        />
+        <input type="radio"
+               name="incident_menus"
+               role="tab"
+               class="tab tab-select [--tab-border:theme(borderWidth.DEFAULT)] [--tab-border-color:theme(colors.primary)]"
+               aria-label="Update Incidents" />
         <div role="tabpanel"
              class="tab-content border-primary [--tab-border:theme(borderWidth.DEFAULT)] rounded-box p-2">
             {% include "htmx/incidents/_incidents_update_menu.html" %}

--- a/src/argus_htmx/templates/htmx/incidents/_incidents_refresh_info.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incidents_refresh_info.html
@@ -1,22 +1,33 @@
-<dl id="table-refresh-info" class="stats stats-horizontal shadow leading-none overflow-x-auto font-medium bg-neutral text-neutral-content">
+<dl id="table-refresh-info"
+    class="stats stats-horizontal shadow leading-none overflow-x-auto font-medium bg-neutral text-neutral-content">
     <div class="stat py-2">
         <dt class="stat-title text-neutral-content/80">Total, all time</dt>
-        <dd class="stat-value text-2xl text-base"> {{ count }}</dd>
+        <dd class="stat-value text-2xl text-base">
+            {{ count }}
+        </dd>
     </div>
     <div class="stat py-2">
         <dt class="stat-title text-neutral-content/80">After filtering</dt>
-        <dd class="stat-value text-2xl text-base"> {{ filtered_count }}</dd>
+        <dd class="stat-value text-2xl text-base">
+            {{ filtered_count }}
+        </dd>
     </div>
     <div class="stat py-2">
         <dt class="stat-title text-neutral-content/80">Per page</dt>
-        <dd class="stat-value text-2xl text-base">{{ per_page }}</dd>
+        <dd class="stat-value text-2xl text-base">
+            {{ per_page }}
+        </dd>
     </div>
     <div class="stat py-2">
         <dt class="stat-title text-neutral-content/80">Last refreshed</dt>
-        <dd class="stat-value text-2xl text-base">{{ last_refreshed|date:"DATETIME_FORMAT"|default:"?" }}</dd>
+        <dd class="stat-value text-2xl text-base">
+            {{ last_refreshed|date:"DATETIME_FORMAT"|default:"?" }}
+        </dd>
     </div>
     <div class="stat py-2">
         <dt class="stat-title text-neutral-content/80">Updating every</dt>
-        <dd class="stat-value text-2xl text-base">{{ update_interval|default:"?" }}s</dd>
+        <dd class="stat-value text-2xl text-base">
+            {{ update_interval|default:"?" }}s
+        </dd>
     </div>
 </dl>

--- a/src/argus_htmx/templates/htmx/incidents/_incidents_update_menu.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incidents_update_menu.html
@@ -1,7 +1,13 @@
 <ul class="menu menu-horizontal gap-2">
     {% block update_menu_content %}
-        <li><button class="btn btn-accent">Add Ticket</button></li>
-        <li><button class="btn btn-accent">Acknowledge</button></li>
-        <li><button class="btn btn-accent">Close/re-open</button></li>
+        <li>
+            <button class="btn btn-accent">Add Ticket</button>
+        </li>
+        <li>
+            <button class="btn btn-accent">Acknowledge</button>
+        </li>
+        <li>
+            <button class="btn btn-accent">Close/re-open</button>
+        </li>
     {% endblock update_menu_content %}
 </ul>

--- a/src/argus_htmx/templates/htmx/incidents/_selected_incidents_header.html
+++ b/src/argus_htmx/templates/htmx/incidents/_selected_incidents_header.html
@@ -1,9 +1,7 @@
-<p class="sr-only">
-    {{ label }}
-</p>
+<p class="sr-only">{{ label }}</p>
 <label for="select-all-on-page-{{ page.number }}" class="sr-only">Select all visible</label>
-<input id="select-all-on-page-{{ page.number }}" hx-preserve type="checkbox" class="checkbox checkbox-sm checkbox-accent border"
-       hx-on:change="htmx.findAll('.row-select').forEach(peer => peer.checked = event.target.checked);
-       event.target.checked ? htmx.find('.tab-select').checked = event.target.checked : null;
-"
-/>
+<input id="select-all-on-page-{{ page.number }}"
+       hx-preserve
+       type="checkbox"
+       class="checkbox checkbox-sm checkbox-accent border"
+       hx-on:change="htmx.findAll('.row-select').forEach(peer => peer.checked = event.target.checked); event.target.checked ? htmx.find('.tab-select').checked = event.target.checked : null; " />

--- a/src/argus_htmx/templates/htmx/incidents/incident_add_ack.html
+++ b/src/argus_htmx/templates/htmx/incidents/incident_add_ack.html
@@ -1,47 +1,39 @@
 {% extends "htmx/base.html" %}
 {% load widget_tweaks %}
-
 {% block main %}
     <h1>Add ack</h1>
-
     {% block list_of_acks %}
         <section id="acks">
             <h2>Acks</h2>
             {% for ack in incident.acks %}
                 <p>Description: {{ ack.event.description }}</p>
                 <p>Expiration: {{ ack.expiration }}</p>
-                <p>Acked by: {{ ack.event.actor }}
+                <p>
+                    Acked by: {{ ack.event.actor }}
                     {% if ack.event.actor.groups.exists %}
-                        <p>Groups:
-                            {% for group in ack.event.actor.groups.all %}
-                                {{ group }}
-                            {% endfor %}
+                        <p>
+                            Groups:
+                            {% for group in ack.event.actor.groups.all %}{{ group }}{% endfor %}
                         </p>
                     {% endif %}
                 </p>
             {% endfor %}
         </section>
     {% endblock list_of_acks %}
-
     {% block add_ack %}
         <section id="add-ack">
-
             {% if request.user.is_authenticated %}
                 <form action="." method="post">
                     {% csrf_token %}
                     <fieldset class="menu menu-horizontal menu-md border border-secondary items-center gap-4">
                         <legend class="menu-title">Add ack</legend>
-
                         {% for field in form %}
                             <label class="input input-bordered flex items-center gap-2">
                                 {{ field.label }}
                                 {{ field|add_class:"appearance-none grow border-none"|append_attr:"placeholder:start writing" }}
                             </label>
-
                         {% empty %}
-                            <p>
-                                Something went wrong
-                            </p>
+                            <p>Something went wrong</p>
                         {% endfor %}
                         <input type="submit" value="Acknowledge" class="btn btn-secondary">
                     </fieldset>

--- a/src/argus_htmx/templates/htmx/incidents/incident_detail.html
+++ b/src/argus_htmx/templates/htmx/incidents/incident_detail.html
@@ -1,141 +1,123 @@
 {% extends "htmx/base.html" %}
-
 {% block main %}
-<div class="flex flex-col items-center gap-4 m-4">
-{% block incident_detail %}
-<h1 class="text-xl font-bold">{{ incident.pk }}: {{ incident.description }}</h1>
-
-<div class="flex gap-4">
-<section id="incident-detail" class="flex-none">
-
-<section id="level" class="card">
-<h2 class="card-title">Level</h2>
-<p class="card-body">
-{{ incident.level }}
-</p>
-</section>
-
-<section id="status" class="card">
-<h2 class="card-title">Status</h2>
-<p class="card-body">
-{% if incident.open %}
-<span class="badge badge-primary">Open</span>{% else %}
-<span class="badge badge-accent">Closed</span>{% endif %}
-{% if incident.acked %}
-<span class="badge badge-primary">Acknowledged</span>{% else %}
-<span class="badge badge-accent">Unacknowledged</span>{% endif %}
-{% if incident.ticket_url %}
-<span class="badge badge-primary"><a href="{{ incident.ticket_url }}" target="_blank">Ticket {{ incident.ticket_url }}</a></span>{% else %}
-<span class="badge badge-accent">No ticket</span>{% endif %}
-</p>
-</section>
-
-<section id="tags" class="card">
-<h2 class="card-title">Tags</h2>
-<p  class="card-body">
-{% for tag in incident.deprecated_tags %}
-<span class="badge badge-neutral">{{ tag }}</span>
-{% endfor %}
-</p>
-</section>
-
-<section id="primary-details" class="card">
-<h2 class="card-title">Primary details (#{{ incident.pk }})</h2>
-
-<div class="card-body">
-<h3 class="font-bold">Description</h3>
-<p>{{ incident.description }}</p>
-
-<h3 class="font-bold">Start time</h3>
-<p>{{ incident.start_time }}</p>
-
-<h3 class="font-bold">Duration</h3>
-<p>{{ incident.end_time }}</p>
-
-<h3 class="font-bold">Source</h3>
-<p>{{ incident.source.name }}</p>
-
-<h3 class="font-bold">Incident id in {{ incident.source.name }}</h3>
-<p>{{ incident.source_incident_id }}</p>
-
-<h3 class="font-bold">More details at</h3>
-<p>
-{% if incident.details_url %}<a href="{{ incident.details_url }}">{{ incident.details_url }}</a>{% else %}—{% endif %}
-</p>
-
-<h3 class="font-bold">Ticket</h3>
-<p>
-{% if incident.ticket_url %}<a href="{{ incident.ticket_url }}" target="_blank">{{ incident.ticket_url }}</a>{% else %}—{% endif %}
-</p>
-
-<div class="card-actions">
-
-{% if incident.stateful %}
-{% if incident.open %}
-{% include 'htmx/incidents/_incident_close_modal.html' with dialog_id="close-incident-dialog" button_title="Close" header="Manually close incident" explanation="Write a message describing why the incident was manually closed" endpoint=endpoints.close cancel_text="Cancel" submit_text="Close now" %}
-{% else %}
-{% include 'htmx/incidents/_incident_reopen_modal.html' with dialog_id="reopen-incident-dialog" button_title="Reopen" header="Manually reopen incident" explanation="Write a message describing why the incident was manually reopend" endpoint=endpoints.reopen cancel_text="Cancel" submit_text="Reopen now" %}
-{% endif %}
-{% endif %}
-
-{% if incident.ticket_url %}
-{% include 'htmx/incidents/_incident_ticket_edit_modal.html' with dialog_id="edit-ticket-dialog" button_title="Edit ticket url" header="Edit ticket" explanation="" endpoint=endpoints.edit_ticket cancel_text="Cancel" submit_text="Update" %}
-{% else %}
-<!-- Manually create ticket dialog -->
-{% include 'htmx/incidents/_incident_ticket_edit_modal.html' with dialog_id="manual-create-ticket-dialog" button_title="Add ticket url" header="Add url to existing ticket" explanation="Are you sure you want to store this url to an existing ticket on this incident?" endpoint=endpoints.add_ticket cancel_text="Cancel" submit_text="Add ticket" %}
-{% endif %}
-
-</div>
-</div>
-</section>
-</section>
-
-<section id="acknowledgements" class="card">
-<h2 class="card-title">Acknowledgements</h2>
-<div class="divide-y divide-solid">
-  {% for ack in incident.acks %}
-  <div class="card-body flex-none">
-    <p>
-    {{ ack.event.description }}
-    </p>
-    <p>
-    {{ ack.event.actor }}
-    {{ ack.event.timestamp }}
-    </p>
-    {% if ack.expiration%}<p>Expires: {{ ack.expiration }}</p>{% endif %}
+    <div class="flex flex-col items-center gap-4 m-4">
+        {% block incident_detail %}
+            <h1 class="text-xl font-bold">{{ incident.pk }}: {{ incident.description }}</h1>
+            <div class="flex gap-4">
+                <section id="incident-detail" class="flex-none">
+                    <section id="level" class="card">
+                        <h2 class="card-title">Level</h2>
+                        <p class="card-body">{{ incident.level }}</p>
+                    </section>
+                    <section id="status" class="card">
+                        <h2 class="card-title">Status</h2>
+                        <p class="card-body">
+                            {% if incident.open %}
+                                <span class="badge badge-primary">Open</span>
+                            {% else %}
+                                <span class="badge badge-accent">Closed</span>
+                            {% endif %}
+                            {% if incident.acked %}
+                                <span class="badge badge-primary">Acknowledged</span>
+                            {% else %}
+                                <span class="badge badge-accent">Unacknowledged</span>
+                            {% endif %}
+                            {% if incident.ticket_url %}
+                                <span class="badge badge-primary"><a href="{{ incident.ticket_url }}" target="_blank">Ticket {{ incident.ticket_url }}</a></span>
+                            {% else %}
+                                <span class="badge badge-accent">No ticket</span>
+                            {% endif %}
+                        </p>
+                    </section>
+                    <section id="tags" class="card">
+                        <h2 class="card-title">Tags</h2>
+                        <p class="card-body">
+                            {% for tag in incident.deprecated_tags %}<span class="badge badge-neutral">{{ tag }}</span>{% endfor %}
+                        </p>
+                    </section>
+                    <section id="primary-details" class="card">
+                        <h2 class="card-title">Primary details (#{{ incident.pk }})</h2>
+                        <div class="card-body">
+                            <h3 class="font-bold">Description</h3>
+                            <p>{{ incident.description }}</p>
+                            <h3 class="font-bold">Start time</h3>
+                            <p>{{ incident.start_time }}</p>
+                            <h3 class="font-bold">Duration</h3>
+                            <p>{{ incident.end_time }}</p>
+                            <h3 class="font-bold">Source</h3>
+                            <p>{{ incident.source.name }}</p>
+                            <h3 class="font-bold">Incident id in {{ incident.source.name }}</h3>
+                            <p>{{ incident.source_incident_id }}</p>
+                            <h3 class="font-bold">More details at</h3>
+                            <p>
+                                {% if incident.details_url %}
+                                    <a href="{{ incident.details_url }}">{{ incident.details_url }}</a>
+                                {% else %}
+                                    —
+                                {% endif %}
+                            </p>
+                            <h3 class="font-bold">Ticket</h3>
+                            <p>
+                                {% if incident.ticket_url %}
+                                    <a href="{{ incident.ticket_url }}" target="_blank">{{ incident.ticket_url }}</a>
+                                {% else %}
+                                    —
+                                {% endif %}
+                            </p>
+                            <div class="card-actions">
+                                {% if incident.stateful %}
+                                    {% if incident.open %}
+                                        {% include 'htmx/incidents/_incident_close_modal.html' with dialog_id="close-incident-dialog" button_title="Close" header="Manually close incident" explanation="Write a message describing why the incident was manually closed" endpoint=endpoints.close cancel_text="Cancel" submit_text="Close now" %}
+                                    {% else %}
+                                        {% include 'htmx/incidents/_incident_reopen_modal.html' with dialog_id="reopen-incident-dialog" button_title="Reopen" header="Manually reopen incident" explanation="Write a message describing why the incident was manually reopend" endpoint=endpoints.reopen cancel_text="Cancel" submit_text="Reopen now" %}
+                                    {% endif %}
+                                {% endif %}
+                                {% if incident.ticket_url %}
+                                    {% include 'htmx/incidents/_incident_ticket_edit_modal.html' with dialog_id="edit-ticket-dialog" button_title="Edit ticket url" header="Edit ticket" explanation="" endpoint=endpoints.edit_ticket cancel_text="Cancel" submit_text="Update" %}
+                                {% else %}
+                                    <!-- Manually create ticket dialog -->
+                                    {% include 'htmx/incidents/_incident_ticket_edit_modal.html' with dialog_id="manual-create-ticket-dialog" button_title="Add ticket url" header="Add url to existing ticket" explanation="Are you sure you want to store this url to an existing ticket on this incident?" endpoint=endpoints.add_ticket cancel_text="Cancel" submit_text="Add ticket" %}
+                                {% endif %}
+                            </div>
+                        </div>
+                    </section>
+                </section>
+                <section id="acknowledgements" class="card">
+                    <h2 class="card-title">Acknowledgements</h2>
+                    <div class="divide-y divide-solid">
+                        {% for ack in incident.acks %}
+                            <div class="card-body flex-none">
+                                <p>{{ ack.event.description }}</p>
+                                <p>
+                                    {{ ack.event.actor }}
+                                    {{ ack.event.timestamp }}
+                                </p>
+                                {% if ack.expiration %}<p>Expires: {{ ack.expiration }}</p>{% endif %}
+                            </div>
+                        {% endfor %}
+                        <div class="card-actions divide-none">
+                            {% include 'htmx/incidents/_incident_acknowledge_modal.html' with dialog_id="create-acknowledgment-dialog" button_title="Create acknowledgment" header="Submit acknowledgment" explanation="Write a message describing why this incident was acknowledged" endpoint=endpoints.ack cancel_text="Cancel" submit_text="Submit" %}
+                        </div>
+                    </div>
+                </section>
+                <section id="events" class="card">
+                    <h2 class="card-title">Related events</h2>
+                    <div class="divide-y divide-solid">
+                        {% for event in incident.events.all %}
+                            {% if not event.ack %}
+                                <div class="card-body flex-none">
+                                    <p>{{ event.get_type_display }}</p>
+                                    <p>{{ event.description }}</p>
+                                    <p>
+                                        {{ event.actor }}
+                                        {{ event.timestamp }}
+                                    </p>
+                                </div>
+                            {% endif %}
+                        {% endfor %}
+                    </div>
+                </section>
+            </div>
+        {% endblock incident_detail %}
     </div>
-    {% endfor %}
-  <div class="card-actions divide-none">
-
-{% include 'htmx/incidents/_incident_acknowledge_modal.html' with dialog_id="create-acknowledgment-dialog" button_title="Create acknowledgment" header="Submit acknowledgment" explanation="Write a message describing why this incident was acknowledged" endpoint=endpoints.ack cancel_text="Cancel" submit_text="Submit" %}
-
-  </div>
-</div>
-</section>
-
-<section id="events" class="card">
-<h2 class="card-title">Related events</h2>
-<div class="divide-y divide-solid">
-{% for event in incident.events.all %}
-{% if not event.ack %}
-<div class="card-body flex-none">
-<p>
-{{ event.get_type_display }}
-</p>
-<p>
-{{ event.description }}
-</p>
-<p>
-{{ event.actor }}
-{{ event.timestamp }}
-</p>
-</div>
-{% endif %}
-{% endfor %}
-</div>
-</section>
-</div>
-
-{% endblock incident_detail %}
-</div>
 {% endblock main %}

--- a/src/argus_htmx/templates/htmx/incidents/incident_list.html
+++ b/src/argus_htmx/templates/htmx/incidents/incident_list.html
@@ -1,21 +1,18 @@
 {% extends base %}
-
 {% block main %}
     <section>
         {% if incidents_extra_widget %}
-        <div class="flex">
-            <div class="w-2/3">{% include "htmx/incidents/_incidents_menubar.html" %}</div>
-            <div class="w-1/3 ml-2">{% include incidents_extra_widget %}</div>
-        </div>
+            <div class="flex">
+                <div class="w-2/3">{% include "htmx/incidents/_incidents_menubar.html" %}</div>
+                <div class="w-1/3 ml-2">{% include incidents_extra_widget %}</div>
+            </div>
         {% else %}
             {% include "htmx/incidents/_incidents_menubar.html" %}
         {% endif %}
     </section>
-
     <section class="overflow-x-auto">
         {% block table %}
             {% include "htmx/incidents/_incident_table.html" %}
         {% endblock table %}
     </section>
-
 {% endblock main %}

--- a/src/argus_htmx/templates/htmx/themes/theme_dropdown.html
+++ b/src/argus_htmx/templates/htmx/themes/theme_dropdown.html
@@ -4,11 +4,11 @@
         <span id="theme-badge" class="badge badge-primary">{{ theme }}</span>
     </summary>
     <ul class="max-h-64 overflow-y-scroll">
-        <li
-                hx-get="{% url 'htmx:theme-names' %}"
-                hx-target="closest ul"
-                hx-swap="innerHTML"
-                hx-trigger="load"
-        ><p>loading...</p></li>
+        <li hx-get="{% url 'htmx:theme-names' %}"
+            hx-target="closest ul"
+            hx-swap="innerHTML"
+            hx-trigger="load">
+            <p>loading...</p>
+        </li>
     </ul>
 </details>

--- a/src/argus_htmx/templates/htmx/themes/theme_list.html
+++ b/src/argus_htmx/templates/htmx/themes/theme_list.html
@@ -9,9 +9,10 @@
                hx-trigger="change"
                hx-swap="textContent"
                hx-target="#theme-badge"
-               hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-        />
+               hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' />
     </li>
 {% empty %}
-    <li><p>empty</p></li>
+    <li>
+        <p>empty</p>
+    </li>
 {% endfor %}

--- a/src/argus_htmx/templates/htmx/themes/themes_list.html
+++ b/src/argus_htmx/templates/htmx/themes/themes_list.html
@@ -1,5 +1,4 @@
 {% extends "htmx/base.html" %}
-
 {% block main %}
     <section>
         <h1>Switch theme</h1>

--- a/src/argus_htmx/templates/htmx_base.html
+++ b/src/argus_htmx/templates/htmx_base.html
@@ -1,30 +1,29 @@
-<!DOCTYPE html>{% load static %}
+<!DOCTYPE html>
+{% load static %}
 <html lang="en-US" data-theme="{{ theme }}">
-<!-- argus/site/templates/base.html -->
-<head>
-    <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    {% block title %}<title>Argus Server: {{ page_title }}</title>{% endblock %}
-    <!-- HTMX -->
-    <script src="{% static "htmx-2.0.2.min.js" %}"></script>
-    <link rel="stylesheet" href="{% static path_to_stylesheet|default:"styles.css" %}">
-
-    {% block head %}
-    {% endblock head %}
-</head>
-<body {% block body_overrides %}class="override bg-base-100"{% endblock %}>
-{% block header %}
-    <h1>Argus Server: {{ page_title }}</h1>
-{% endblock header %}
-
-<main class="space-y-2 p-1">
-    {% block main %}
-    {% endblock main %}
-</main>
-
-{% block footer %}
-{% endblock footer %}
-
-{% block tail %}{% endblock tail %}
-</body>
+    <!-- argus/site/templates/base.html -->
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        {% block title %}<title>Argus Server: {{ page_title }}</title>{% endblock %}
+        <!-- HTMX -->
+        <script src="{% static "htmx-2.0.2.min.js" %}"></script>
+        <link rel="stylesheet"
+              href="{% static path_to_stylesheet|default:"styles.css" %}">
+        {% block head %}
+        {% endblock head %}
+    </head>
+    <body {% block body_overrides %}class="override bg-base-100"{% endblock %}>
+        {% block header %}
+            <h1>Argus Server: {{ page_title }}</h1>
+        {% endblock header %}
+        <main class="space-y-2 p-1">
+            {% block main %}
+            {% endblock main %}
+        </main>
+        {% block footer %}
+        {% endblock footer %}
+        {% block tail %}
+        {% endblock tail %}
+    </body>
 </html>

--- a/src/argus_htmx/templates/registration/login.html
+++ b/src/argus_htmx/templates/registration/login.html
@@ -1,35 +1,29 @@
 {% extends "htmx/base.html" %}
 {% load widget_tweaks %}
-
 {% block main %}
-<div class="p-6 flex justify-center">
-  <div class="card border border-primary p-2 w-full sm:w-96 flex items-center">
-    <h2 class="card-title">Log In</h2>
-
-    <section class="card-body">
-    <form method="post" class="flex flex-col gap-6">
-      {% csrf_token %}
-      {% for field in form %}
-      <label class="flex flex-row items-center gap-2">
-        <span class="w-24">{{ field.label }}:</span>
-        <div class="indicator">
-          <span class="indicator-item indicator-top indicator-start badge border-none mask mask-circle text-warning text-base">＊</span>
-          {{ field|add_class:"input input-bordered border-accent grow" }}
-        </div>
-      </label>
-      {% endfor %}
-      <button type="submit" class="btn btn-primary">Log In</button>
-    </form>
-    </section>
-
-    {% comment %}
+    <div class="p-6 flex justify-center">
+        <div class="card border border-primary p-2 w-full sm:w-96 flex items-center">
+            <h2 class="card-title">Log In</h2>
+            <section class="card-body">
+                <form method="post" class="flex flex-col gap-6">
+                    {% csrf_token %}
+                    {% for field in form %}
+                        <label class="flex flex-row items-center gap-2">
+                            <span class="w-24">{{ field.label }}:</span>
+                            <div class="indicator">
+                                <span class="indicator-item indicator-top indicator-start badge border-none mask mask-circle text-warning text-base">＊</span>
+                                {{ field|add_class:"input input-bordered border-accent grow" }}
+                            </div>
+                        </label>
+                    {% endfor %}
+                    <button type="submit" class="btn btn-primary">Log In</button>
+                </form>
+            </section>
+            {% comment %}
     <section>
     <h3>Federated logins</h3>
-    {% for backend in oauth2_backends %}
-    <a href="/oidc/login/{{ backend }}/">{{ backend }}</a>
-    {% endfor %}
+    {% for backend in oauth2_backends %}<a href="/oidc/login/{{ backend }}/">{{ backend }}</a>{% endfor %}
     </section>
-    {% endcomment %}
-
-</div>
-{% endblock main %}
+            {% endcomment %}
+        </div>
+    {% endblock main %}

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+    extends: ['stylelint-config-standard'],
+    rules: {
+        'at-rule-no-unknown': [
+            true,
+            {
+                ignoreAtRules: [
+                    'tailwind',
+                    'apply',
+                    'variants',
+                    'responsive',
+                    'screen',
+                ],
+            },
+        ],
+        'no-descending-specificity': null,
+    },
+}


### PR DESCRIPTION
Closes #40.

djLint will be used to format and lint HTML files and stylelint to lint CSS files. I have not added formatting of CSS files since that is not supported in MegaLinter as far as I found out and otherwise I am too unsure what to use to format CSS files. 

MegaLinter is currently failing because linting some HTML files produces errors. I would like some help to fix these errors or to tell me that these rules can be ignored.  