### PR TITLE
Add path for finding content under current dir

### DIFF
--- a/src/argus_htmx/tailwindtheme/tailwind.config.js
+++ b/src/argus_htmx/tailwindtheme/tailwind.config.js
@@ -1,5 +1,6 @@
 const projectPaths = [
     '../templates/**/*.html',
+    './**/templates/**/*.html',
 ];
 
 const contentPaths = [...projectPaths];

--- a/src/argus_htmx/tailwindtheme/tailwind.config.template.js
+++ b/src/argus_htmx/tailwindtheme/tailwind.config.template.js
@@ -1,6 +1,7 @@
 const projectPaths = [
     '../templates/**/*.html',
     './**/templates/**/*.html',
+    'src/argus_htmx/**/*.html'
 ];
 
 const contentPaths = [...projectPaths];

--- a/src/argus_htmx/tailwindtheme/tailwind.config.template.js
+++ b/src/argus_htmx/tailwindtheme/tailwind.config.template.js
@@ -1,7 +1,7 @@
 const projectPaths = [
     '../templates/**/*.html',
     './**/templates/**/*.html',
-    'src/argus_htmx/**/*.html'
+    'src/argus_htmx/templates/**/*.html'
 ];
 
 const contentPaths = [...projectPaths];

--- a/src/argus_htmx/tailwindtheme/tailwind.config.template.js
+++ b/src/argus_htmx/tailwindtheme/tailwind.config.template.js
@@ -1,5 +1,6 @@
 const projectPaths = [
     '../templates/**/*.html',
+    './**/templates/**/*.html',
 ];
 
 const contentPaths = [...projectPaths];


### PR DESCRIPTION
Previously required you to stand a step deeper than `src/argus_htmx` in order for tailwind to find html content (the path did a `../templates`, so you had to go a step back then into templates)

This PR find all templates under the current dir, so should work for repo root and anywhere above templates