### PR TITLE
Add dropdown for user to choose datetime format

### DIFF
--- a/src/argus_htmx/context_processors.py
+++ b/src/argus_htmx/context_processors.py
@@ -1,19 +1,28 @@
 """
-This should probably be in a separate 3rd party theming-app!
-
 How to use:
 
-Update the "context_processors" list for the TEMPLATES-backend
-``django.template.backends.django.DjangoTemplates`` with *one* of these.
+Append the "context_processors" list for the TEMPLATES-backend
+``django.template.backends.django.DjangoTemplates`` with the full dotted path.
 
 See django settings for ``TEMPLATES``.
 """
 
 def theme_via_GET(request):
+    # Move to theme-app?
     theme = request.GET.get("theme", None)
     return {"theme": theme}
 
 
 def theme_via_session(request):
+    # Move to theme-app?
     theme = request.session.get("theme", None)
     return {"theme": theme}
+
+
+def datetime_format_via_session(request):
+    datetime_format = request.session.get("datetime_format", "DATETIME_FORMAT")  # fallback to locale
+    datetime_format_name = request.session.get("datetime_format_name", "LOCALE")  # fallback to locale
+    return {
+        "datetime_format": datetime_format,
+        "datetime_format_name": datetime_format_name,
+    }

--- a/src/argus_htmx/context_processors.py
+++ b/src/argus_htmx/context_processors.py
@@ -6,6 +6,8 @@ Append the "context_processors" list for the TEMPLATES-backend
 
 See django settings for ``TEMPLATES``.
 """
+from .dateformat.constants import DATETIME_DEFAULT, DATETIME_FORMATS
+
 
 def theme_via_GET(request):
     # Move to theme-app?
@@ -20,8 +22,11 @@ def theme_via_session(request):
 
 
 def datetime_format_via_session(request):
-    datetime_format = request.session.get("datetime_format", "DATETIME_FORMAT")  # fallback to locale
     datetime_format_name = request.session.get("datetime_format_name", "LOCALE")  # fallback to locale
+    if datetime_format_name not in DATETIME_FORMATS.values():
+        datetime_format_name = DATETIME_DEFAULT
+    # The named format always wins
+    datetime_format = DATETIME_FORMATS[datetime_format_name]
     return {
         "datetime_format": datetime_format,
         "datetime_format_name": datetime_format_name,

--- a/src/argus_htmx/context_processors.py
+++ b/src/argus_htmx/context_processors.py
@@ -23,7 +23,7 @@ def theme_via_session(request):
 
 def datetime_format_via_session(request):
     datetime_format_name = request.session.get("datetime_format_name", "LOCALE")  # fallback to locale
-    if datetime_format_name not in DATETIME_FORMATS.values():
+    if datetime_format_name not in DATETIME_FORMATS:
         datetime_format_name = DATETIME_DEFAULT
     # The named format always wins
     datetime_format = DATETIME_FORMATS[datetime_format_name]

--- a/src/argus_htmx/dateformat/constants.py
+++ b/src/argus_htmx/dateformat/constants.py
@@ -1,7 +1,22 @@
-DATETIME_DEFAULT = 'LOCALE'
+from django.conf import settings
+
+__all__ = [
+    "DATETIME_FALLBACK",
+    "DATETIME_FORMATS",
+    "DATETIME_DEFAULT",
+]
+
+
+DATETIME_FALLBACK = 'LOCALE'
 DATETIME_FORMATS = {
     'LOCALE': 'DATETIME_FORMAT',  # default
     'ISO': 'Y-m-d H:i:s',
     'RFC5322': 'r',
     'EPOCH': 'U',
 }
+
+_datetime_setting = getattr(settings, "ARGUS_FRONTEND_DATETIME_FORMAT", DATETIME_FALLBACK)
+
+DATETIME_DEFAULT = DATETIME_FALLBACK
+if _datetime_setting in DATETIME_FORMATS:
+    DATETIME_DEFAULT = _datetime_setting

--- a/src/argus_htmx/dateformat/constants.py
+++ b/src/argus_htmx/dateformat/constants.py
@@ -1,0 +1,7 @@
+DATETIME_DEFAULT = 'LOCALE'
+DATETIME_FORMATS = {
+    'LOCALE': 'DATETIME_FORMAT',  # default
+    'ISO': 'Y-m-d H:i:s',
+    'RFC5322': 'r',
+    'EPOCH': 'U',
+}

--- a/src/argus_htmx/dateformat/urls.py
+++ b/src/argus_htmx/dateformat/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from . import views
+
+
+app_name = "htmx"
+urlpatterns = [
+    path("names/", views.dateformat_names, name="dateformat-names"),
+    path("change/", views.change_dateformat, name="change-dateformat"),
+]

--- a/src/argus_htmx/dateformat/views.py
+++ b/src/argus_htmx/dateformat/views.py
@@ -8,15 +8,9 @@ from django.http import HttpResponse
 from django_htmx.http import HttpResponseClientRefresh
 
 from argus_htmx.incidents.views import HtmxHttpRequest
+from .constants import DATETIME_DEFAULT, DATETIME_FORMATS
 
 LOG = logging.getLogger(__name__)
-DATETIME_DEFAULT = 'LOCALE'
-DATETIME_FORMATS = {
-    'LOCALE': 'DATETIME_FORMAT',  # default
-    'ISO': 'Y-m-d H:i:s',
-    'RFC5322': 'r',
-    'EPOCH': 'U',
-}
 
 
 @require_GET
@@ -28,7 +22,8 @@ def dateformat_names(request: HtmxHttpRequest) -> HttpResponse:
 @require_POST
 def change_dateformat(request: HtmxHttpRequest) -> HttpResponse:
     datetime_format_name = request.POST.get("dateformat", DATETIME_DEFAULT)
-    datetime_format = DATETIME_FORMATS[datetime_format_name]
+    default_format = DATETIME_FORMATS[DATETIME_DEFAULT]
+    datetime_format = DATETIME_FORMATS.get(datetime_format_name, default_format)
     request.session["datetime_format"] = datetime_format
     request.session["datetime_format_name"] = datetime_format_name
     messages.success(request, f'Switched dateformat to "{datetime_format_name}"')

--- a/src/argus_htmx/dateformat/views.py
+++ b/src/argus_htmx/dateformat/views.py
@@ -1,0 +1,37 @@
+import logging
+
+from django.contrib import messages
+from django.shortcuts import render
+
+from django.views.decorators.http import require_GET, require_POST
+from django.http import HttpResponse
+from django_htmx.http import HttpResponseClientRefresh
+
+from argus_htmx.incidents.views import HtmxHttpRequest
+
+LOG = logging.getLogger(__name__)
+DATETIME_DEFAULT = 'LOCALE'
+DATETIME_FORMATS = {
+    'LOCALE': 'DATETIME_FORMAT',  # default
+    'ISO': 'Y-m-d H:i:s',
+    'RFC5322': 'r',
+    'EPOCH': 'U',
+}
+
+
+@require_GET
+def dateformat_names(request: HtmxHttpRequest) -> HttpResponse:
+    datetime_formats = DATETIME_FORMATS.keys()
+    return render(request, "htmx/dateformat/_dateformat_list.html", {"datetime_formats": datetime_formats})
+
+
+@require_POST
+def change_dateformat(request: HtmxHttpRequest) -> HttpResponse:
+    datetime_format_name = request.POST.get("dateformat", DATETIME_DEFAULT)
+    if datetime_format_name in DATETIME_FORMATS:
+        datetime_format = DATETIME_FORMATS[datetime_format_name]
+        request.session["datetime_format"] = datetime_format
+        request.session["datetime_format_name"] = datetime_format_name
+        messages.success(request, f'Switched dateformat to "{datetime_format_name}"')
+        return HttpResponse(f'{datetime_format_name}')
+    return HttpResponseClientRefresh()

--- a/src/argus_htmx/dateformat/views.py
+++ b/src/argus_htmx/dateformat/views.py
@@ -28,10 +28,8 @@ def dateformat_names(request: HtmxHttpRequest) -> HttpResponse:
 @require_POST
 def change_dateformat(request: HtmxHttpRequest) -> HttpResponse:
     datetime_format_name = request.POST.get("dateformat", DATETIME_DEFAULT)
-    if datetime_format_name in DATETIME_FORMATS:
-        datetime_format = DATETIME_FORMATS[datetime_format_name]
-        request.session["datetime_format"] = datetime_format
-        request.session["datetime_format_name"] = datetime_format_name
-        messages.success(request, f'Switched dateformat to "{datetime_format_name}"')
-        return HttpResponse(f'{datetime_format_name}')
+    datetime_format = DATETIME_FORMATS[datetime_format_name]
+    request.session["datetime_format"] = datetime_format
+    request.session["datetime_format_name"] = datetime_format_name
+    messages.success(request, f'Switched dateformat to "{datetime_format_name}"')
     return HttpResponseClientRefresh()

--- a/src/argus_htmx/templates/htmx/base.html
+++ b/src/argus_htmx/templates/htmx/base.html
@@ -42,6 +42,9 @@
                                     {% include 'htmx/themes/theme_dropdown.html' %}
                                 </li>
                                 <li>
+                                    {% include 'htmx/dateformat/_dateformat_dropdown.html' %}
+                                </li>
+                                <li>
                                     <form class="flex" action="{% url "htmx:logout" %}" method="POST">
                                         {% csrf_token %}
                                         <button class="flex-1 text-start" type="submit">Log out</button>

--- a/src/argus_htmx/templates/htmx/dateformat/_dateformat_dropdown.html
+++ b/src/argus_htmx/templates/htmx/dateformat/_dateformat_dropdown.html
@@ -1,0 +1,14 @@
+<details>
+    <summary>
+        Date format
+        <span id="dateformat-badge" class="badge badge-primary">{{ datetime_format_name }}</span>
+    </summary>
+    <ul class="max-h-64 overflow-y-scroll">
+        <li
+                hx-get="{% url 'htmx:dateformat-names' %}"
+                hx-target="closest ul"
+                hx-swap="innerHTML"
+                hx-trigger="load"
+        ><p>loading...</p></li>
+    </ul>
+</details>

--- a/src/argus_htmx/templates/htmx/dateformat/_dateformat_list.html
+++ b/src/argus_htmx/templates/htmx/dateformat/_dateformat_list.html
@@ -1,0 +1,17 @@
+{% for item in datetime_formats %}
+    <li>
+        <input type="radio"
+               class="btn btn-sm btn-block btn-ghost justify-start"
+               value="{{ item }}"
+               aria-label="{{ item }}"
+               name="dateformat"
+               hx-post="{% url 'htmx:change-dateformat' %}"
+               hx-trigger="change"
+               hx-swap="textContent"
+               hx-target="#dateformat-badge"
+               hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+        />
+    </li>
+{% empty %}
+    <li><p>No date formats configured</p></li>
+{% endfor %}

--- a/src/argus_htmx/templates/htmx/incidents/_incident_start_time.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_start_time.html
@@ -1,1 +1,1 @@
-{{ incident.start_time }}
+{{ incident.start_time|date:datetime_format }}

--- a/src/argus_htmx/templates/htmx/incidents/_incidents_refresh_info.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incidents_refresh_info.html
@@ -13,7 +13,7 @@
     </div>
     <div class="stat py-2">
         <dt class="stat-title text-neutral-content/80">Last refreshed</dt>
-        <dd class="stat-value text-2xl text-base">{{ last_refreshed|date:"DATETIME_FORMAT"|default:"?" }}</dd>
+        <dd class="stat-value text-2xl text-base">{{ last_refreshed|date:datetime_format|default:"?" }}</dd>
     </div>
     <div class="stat py-2">
         <dt class="stat-title text-neutral-content/80">Updating every</dt>

--- a/src/argus_htmx/templates/htmx/incidents/incident_detail.html
+++ b/src/argus_htmx/templates/htmx/incidents/incident_detail.html
@@ -47,10 +47,10 @@
 <p>{{ incident.description }}</p>
 
 <h3 class="font-bold">Start time</h3>
-<p>{{ incident.start_time }}</p>
+<p>{{ incident.start_time|date:datetime_format }}</p>
 
 <h3 class="font-bold">Duration</h3>
-<p>{{ incident.end_time }}</p>
+<p>{{ incident.end_time|date:datetime_format }}</p>
 
 <h3 class="font-bold">Source</h3>
 <p>{{ incident.source.name }}</p>
@@ -100,9 +100,9 @@
     </p>
     <p>
     {{ ack.event.actor }}
-    {{ ack.event.timestamp }}
+    {{ ack.event.timestamp|date:datetime_format }}
     </p>
-    {% if ack.expiration%}<p>Expires: {{ ack.expiration }}</p>{% endif %}
+    {% if ack.expiration%}<p>Expires: {{ ack.expiration|date:datetime_format }}</p>{% endif %}
     </div>
     {% endfor %}
   <div class="card-actions divide-none">
@@ -127,7 +127,7 @@
 </p>
 <p>
 {{ event.actor }}
-{{ event.timestamp }}
+{{ event.timestamp|date:datetime_format }}
 </p>
 </div>
 {% endif %}

--- a/src/argus_htmx/urls.py
+++ b/src/argus_htmx/urls.py
@@ -9,6 +9,7 @@ from .timeslots.urls import urlpatterns as timeslot_urls
 from .notificationprofiles.urls import urlpatterns as notificationprofile_urls
 from .destinations.urls import urlpatterns as destination_urls
 from .themes.urls import urlpatterns as theme_urls
+from .dateformat.urls import urlpatterns as dateformat_urls
 
 app_name = "htmx"
 urlpatterns = [
@@ -24,4 +25,5 @@ urlpatterns = [
     path("notificationprofiles/", include(notificationprofile_urls)),
     path("destinations/", include(destination_urls)),
     path("themes/", include(theme_urls)),
+    path("dateformat/", include(dateformat_urls)),
 ]


### PR DESCRIPTION
Closes #100

This is based very closely on the theme-switching UX.

Set up: add "argus_htmx.context_processors.datetime_format_via_session" to the context_processors" in the TEMPLATES-setting in your localsettings-file, or change the argus_htmx-entry in EXTRA_APPS to:

```
  {
    "app_name": "argus_htmx",
    "urls": {
      "path": "",
      "urlpatterns_module": "argus_htmx.urls"
    },
    "context_processors": [
      "argus_htmx.context_processors.theme_via_session",
      "argus_htmx.context_processors.datetime_format_via_session"
    ],
    "middleware": {
      "argus_htmx.middleware.LoginRequiredMiddleware": "end"
    }
  },
```

One difference from the themes: in order to actually switch to the new format, the page is always refreshed. There might be redundant htmx-code for that reason.

There's a new optional setting `ARGUS_FRONTEND_DATETIME_FORMAT` that sets the default format. If not set i fall backs to using locale.