### PR TITLE
Fix width for menubar tabs to prevent wrapping

### DIFF
--- a/src/argus_htmx/static/styles.css
+++ b/src/argus_htmx/static/styles.css
@@ -3567,10 +3567,6 @@ input.tab:checked + .tab-content,
   margin: 1rem;
 }
 
-.m-8 {
-  margin: 2rem;
-}
-
 .my-0 {
   margin-top: 0px;
   margin-bottom: 0px;
@@ -3622,12 +3618,24 @@ input.tab:checked + .tab-content,
   max-height: 100svh;
 }
 
+.\!w-32 {
+  width: 8rem !important;
+}
+
+.\!w-36 {
+  width: 9rem !important;
+}
+
 .w-1\/3 {
   width: 33.333333%;
 }
 
 .w-2\/3 {
   width: 66.666667%;
+}
+
+.w-24 {
+  width: 6rem;
 }
 
 .w-52 {
@@ -3678,6 +3686,10 @@ input.tab:checked + .tab-content,
           appearance: none;
 }
 
+.flex-row {
+  flex-direction: row;
+}
+
 .flex-col {
   flex-direction: column;
 }
@@ -3690,6 +3702,10 @@ input.tab:checked + .tab-content,
   justify-content: flex-start;
 }
 
+.justify-center {
+  justify-content: center;
+}
+
 .justify-between {
   justify-content: space-between;
 }
@@ -3700,6 +3716,10 @@ input.tab:checked + .tab-content,
 
 .gap-4 {
   gap: 1rem;
+}
+
+.gap-6 {
+  gap: 1.5rem;
 }
 
 .space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -3758,6 +3778,11 @@ input.tab:checked + .tab-content,
   border-style: none;
 }
 
+.border-accent {
+  --tw-border-opacity: 1;
+  border-color: var(--fallback-a,oklch(var(--a)/var(--tw-border-opacity)));
+}
+
 .border-primary {
   --tw-border-opacity: 1;
   border-color: var(--fallback-p,oklch(var(--p)/var(--tw-border-opacity)));
@@ -3798,6 +3823,10 @@ input.tab:checked + .tab-content,
 
 .p-2 {
   padding: 0.5rem;
+}
+
+.p-6 {
+  padding: 1.5rem;
 }
 
 .px-1 {
@@ -3934,4 +3963,10 @@ input.tab:checked + .tab-content,
 
 .\[--tab-border\:theme\(borderWidth\.DEFAULT\)\] {
   --tab-border: 2px;
+}
+
+@media (min-width: 640px) {
+  .sm\:w-96 {
+    width: 24rem;
+  }
 }

--- a/src/argus_htmx/templates/htmx/incidents/_incidents_menubar.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incidents_menubar.html
@@ -1,9 +1,9 @@
 <div role="tablist" class="tabs tabs-lifted">
     {% block menu_tabs %}
-        <input type="radio" 
-               name="incident_menus" 
+        <input type="radio"
+               name="incident_menus"
                role="tab"
-               class="tab [--tab-border:theme(borderWidth.DEFAULT)] [--tab-border-color:theme(colors.primary)]"
+               class="tab [--tab-border:theme(borderWidth.DEFAULT)] [--tab-border-color:theme(colors.primary)] !w-32"
                aria-label="Filter Incidents"
                checked="checked"
         />
@@ -15,7 +15,7 @@
                 type="radio"
                 name="incident_menus"
                 role="tab"
-                class="tab tab-select [--tab-border:theme(borderWidth.DEFAULT)] [--tab-border-color:theme(colors.primary)]"
+                class="tab tab-select [--tab-border:theme(borderWidth.DEFAULT)] [--tab-border-color:theme(colors.primary)] !w-36"
                 aria-label="Update Incidents"
         />
         <div role="tabpanel"


### PR DESCRIPTION
Fixes #132 

Daisy tabs component overrides width to `auto` which can result in a decreased width (why exactly I don't know). This PR fixes the width to a value so that the tab content doesn't wrap. 