### PR TITLE
Pick DATETIME_DEFAULT for empty sessions

### DIFF
--- a/src/argus_htmx/context_processors.py
+++ b/src/argus_htmx/context_processors.py
@@ -22,7 +22,7 @@ def theme_via_session(request):
 
 
 def datetime_format_via_session(request):
-    datetime_format_name = request.session.get("datetime_format_name", "LOCALE")  # fallback to locale
+    datetime_format_name = request.session.get("datetime_format_name")
     if datetime_format_name not in DATETIME_FORMATS:
         datetime_format_name = DATETIME_DEFAULT
     # The named format always wins


### PR DESCRIPTION
Currently DATETIME_DEFAULT is not considered for new django sessions (if `datetime_format_name` is not in the session) but the default datetime format is hardcoded to `LOCALE`, limiting the usefulness of `ARGUS_FRONTEND_DATETIME_FORMAT`

this fixes that