### PR TITLE
Selectable incident list page size

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -335,3 +335,12 @@ You could then create ``path/to/_extra_widget.html`` as following::
     <div id="service-status" class="border border-primary rounded-2xl h-full p-2">
       My custom widget
     </div>
+
+
+Page size
+---------
+
+By default, incidents are shown with a page size of ``10`` (ie. 10 rows at a time), and the user can
+select a different page size from ``[10, 20, 50, 100]``. It possible to override these settings by
+setting the ``ARGUS_INCIDENTS_DEFAULT_PAGE_SIZE`` and ``ARGUS_INCIDENTS_PAGE_SIZES`` setting
+respectively.

--- a/src/argus_htmx/incidents/views.py
+++ b/src/argus_htmx/incidents/views.py
@@ -218,7 +218,7 @@ def incident_list(request: HtmxHttpRequest) -> HttpResponse:
         "base": base_template,
         "page": page,
         "last_refreshed": last_refreshed,
-        "update_interval": 3000,
+        "update_interval": 30,
         "page_size": page_size,
         "all_page_sizes": ALLOWED_PAGE_SIZES
     }

--- a/src/argus_htmx/incidents/views.py
+++ b/src/argus_htmx/incidents/views.py
@@ -4,6 +4,7 @@ import logging
 from typing import Optional
 from datetime import datetime
 
+from django.conf import settings
 from django.contrib.auth.models import Group
 from django.contrib.auth import get_user_model
 from django.contrib import messages
@@ -26,7 +27,8 @@ from .forms import AckForm, DescriptionOptionalForm, EditTicketUrlForm, AddTicke
 
 User = get_user_model()
 LOG = logging.getLogger(__name__)
-
+DEFAULT_PAGE_SIZE = getattr(settings, "ARGUS_INCIDENTS_DEFAULT_PAGE_SIZE", 10)
+ALLOWED_PAGE_SIZES = getattr(settings, "ARGUS_INCIDENTS_PAGE_SIZES", [10, 20, 50, 100])
 
 def prefetch_incident_daughters():
     return (
@@ -171,6 +173,14 @@ def incident_detail_edit_ticket(request, pk: int):
     return redirect("htmx:incident-detail", pk=pk)
 
 
+def _get_page_size(params):
+    try:
+        if (page_size:=int(params.pop('page_size', DEFAULT_PAGE_SIZE))) in ALLOWED_PAGE_SIZES:
+            return page_size
+    except ValueError:
+        pass
+    return DEFAULT_PAGE_SIZE
+
 @require_GET
 def incident_list(request: HtmxHttpRequest) -> HttpResponse:
     columns = get_incident_table_columns()
@@ -188,8 +198,8 @@ def incident_list(request: HtmxHttpRequest) -> HttpResponse:
 
     # Standard Django pagination
     page_num = params.pop("page", "1")
-    PAGE_SIZE = 10
-    paginator = Paginator(object_list=qs, per_page=PAGE_SIZE)
+    page_size = _get_page_size(params)
+    paginator = Paginator(object_list=qs, per_page=page_size)
     page = paginator.get_page(page_num)
 
     # The htmx magic - use a different, minimal base template for htmx
@@ -208,8 +218,9 @@ def incident_list(request: HtmxHttpRequest) -> HttpResponse:
         "base": base_template,
         "page": page,
         "last_refreshed": last_refreshed,
-        "update_interval": 30,
-        "per_page": PAGE_SIZE,
+        "update_interval": 3000,
+        "page_size": page_size,
+        "all_page_sizes": ALLOWED_PAGE_SIZES
     }
 
     return render(request, "htmx/incidents/incident_list.html", context=context)

--- a/src/argus_htmx/templates/htmx/incidents/_incident_filterbox.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_filterbox.html
@@ -1,13 +1,13 @@
 {% load widget_tweaks %}
-<form>
-    <fieldset
-            hx-get="{% url 'htmx:incident-list' %}"
-            hx-include="this"
-            hx-trigger="change delay:100ms"
-            hx-target="#table"
-            hx-swap="outerHTML"
-            hx-push-url="true"
-    >
+<form id="incident-filter-box"
+      hx-get="{% url 'htmx:incident-list' %}"
+      hx-include="#table-refresh-info, #incident-filter-box"
+      hx-trigger="keydown[keyCode==13], change delay:100ms"
+      hx-target="#table"
+      hx-swap="outerHTML"
+      hx-push-url="true"
+      onkeydown="if (event.keyCode === 13) event.preventDefault();">
+    <fieldset>
         <legend class="sr-only">Filter incidents</legend>
         <ul class="menu menu-horizontal menu-sm flex items-center gap-2 py-1.5">
             {% for field in filter_form %}

--- a/src/argus_htmx/templates/htmx/incidents/_incident_table.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_table.html
@@ -4,7 +4,7 @@
        hx-swap="outerHTML"
        hx-trigger="every {{ update_interval|default:'30' }}s"
        hx-push-url="true"
-       hx-include=".filterbox fieldset"
+       hx-include="#table-refresh-info, #incident-filter-box"
        class="border border-separate border-spacing-1 border-primary table"
 >
     <thead>

--- a/src/argus_htmx/templates/htmx/incidents/_incidents_refresh_info.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incidents_refresh_info.html
@@ -2,16 +2,16 @@
     <dl class="stats stats-horizontal shadow leading-none overflow-x-auto font-medium bg-neutral text-neutral-content">
         <div class="stat py-2">
             <dt class="stat-title text-neutral-content/80">Total, all time</dt>
-            <dd class="stat-value text-2xl text-base"> {{ count }}</dd>
+            <dd class="stat-value text-base"> {{ count }}</dd>
         </div>
         <div class="stat py-2">
             <dt class="stat-title text-neutral-content/80">After filtering</dt>
-            <dd class="stat-value text-2xl text-base"> {{ filtered_count }}</dd>
+            <dd class="stat-value text-base"> {{ filtered_count }}</dd>
         </div>
         <div class="stat py-2">
             <dt class="stat-title text-neutral-content/80">Per page</dt>
-            <dd class="stat-value text-2xl text-primary">
-                <select class="select select-xs" name="page_size">
+            <dd class="stat-value text-base">
+                <select class="select select-xs bg-neutral text-base border-none -ml-2" name="page_size">
                     {% for ps in all_page_sizes %}
                         <option value="{{ ps }}" {% if ps == page_size %}selected{% endif %}>{{ ps }}</option>
                     {% endfor %}
@@ -20,11 +20,11 @@
         </div>
         <div class="stat py-2">
             <dt class="stat-title text-neutral-content/80">Last refreshed</dt>
-            <dd class="stat-value text-2xl text-base">{{ last_refreshed|date:datetime_format|default:"?" }}</dd>
+            <dd class="stat-value text-base">{{ last_refreshed|date:datetime_format|default:"?" }}</dd>
         </div>
         <div class="stat py-2">
             <dt class="stat-title text-neutral-content/80">Updating every</dt>
-            <dd class="stat-value text-2xl text-base">{{ update_interval|default:"?" }}s</dd>
+            <dd class="stat-value text-base">{{ update_interval|default:"?" }}s</dd>
         </div>
     </dl>
 </form>

--- a/src/argus_htmx/templates/htmx/incidents/_incidents_refresh_info.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incidents_refresh_info.html
@@ -11,7 +11,7 @@
         <div class="stat py-2">
             <dt class="stat-title text-neutral-content/80">Per page</dt>
             <dd class="stat-value text-base">
-                <select class="select select-xs bg-neutral text-base border-none -ml-2" name="page_size">
+                <select class="select select-xs bg-transparent text-base border-none -ml-2" name="page_size">
                     {% for ps in all_page_sizes %}
                         <option value="{{ ps }}" {% if ps == page_size %}selected{% endif %}>{{ ps }}</option>
                     {% endfor %}

--- a/src/argus_htmx/templates/htmx/incidents/_incidents_refresh_info.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incidents_refresh_info.html
@@ -13,7 +13,7 @@
             <dd class="stat-value text-base">
                 <select class="select select-xs bg-transparent text-base border-none -ml-2" name="page_size">
                     {% for ps in all_page_sizes %}
-                        <option value="{{ ps }}" {% if ps == page_size %}selected{% endif %}>{{ ps }}</option>
+                        <option class="bg-neutral" value="{{ ps }}" {% if ps == page_size %}selected{% endif %}>{{ ps }}</option>
                     {% endfor %}
                 </select>
             </dd>

--- a/src/argus_htmx/templates/htmx/incidents/_incidents_refresh_info.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incidents_refresh_info.html
@@ -1,22 +1,30 @@
-<dl id="table-refresh-info" class="stats stats-horizontal shadow leading-none overflow-x-auto font-medium bg-neutral text-neutral-content">
-    <div class="stat py-2">
-        <dt class="stat-title text-neutral-content/80">Total, all time</dt>
-        <dd class="stat-value text-2xl text-base"> {{ count }}</dd>
-    </div>
-    <div class="stat py-2">
-        <dt class="stat-title text-neutral-content/80">After filtering</dt>
-        <dd class="stat-value text-2xl text-base"> {{ filtered_count }}</dd>
-    </div>
-    <div class="stat py-2">
-        <dt class="stat-title text-neutral-content/80">Per page</dt>
-        <dd class="stat-value text-2xl text-base">{{ per_page }}</dd>
-    </div>
-    <div class="stat py-2">
-        <dt class="stat-title text-neutral-content/80">Last refreshed</dt>
-        <dd class="stat-value text-2xl text-base">{{ last_refreshed|date:datetime_format|default:"?" }}</dd>
-    </div>
-    <div class="stat py-2">
-        <dt class="stat-title text-neutral-content/80">Updating every</dt>
-        <dd class="stat-value text-2xl text-base">{{ update_interval|default:"?" }}s</dd>
-    </div>
-</dl>
+<form hx-get="{% url 'htmx:incident-list' %}" id="table-refresh-info" hx-trigger="change" hx-target="#table" hx-swap="outerHTML">
+    <dl class="stats stats-horizontal shadow leading-none overflow-x-auto font-medium bg-neutral text-neutral-content">
+        <div class="stat py-2">
+            <dt class="stat-title text-neutral-content/80">Total, all time</dt>
+            <dd class="stat-value text-2xl text-base"> {{ count }}</dd>
+        </div>
+        <div class="stat py-2">
+            <dt class="stat-title text-neutral-content/80">After filtering</dt>
+            <dd class="stat-value text-2xl text-base"> {{ filtered_count }}</dd>
+        </div>
+        <div class="stat py-2">
+            <dt class="stat-title text-neutral-content/80">Per page</dt>
+            <dd class="stat-value text-2xl text-primary">
+                <select class="select select-xs" name="page_size">
+                    {% for ps in all_page_sizes %}
+                        <option value="{{ ps }}" {% if ps == page_size %}selected{% endif %}>{{ ps }}</option>
+                    {% endfor %}
+                </select>
+            </dd>
+        </div>
+        <div class="stat py-2">
+            <dt class="stat-title text-neutral-content/80">Last refreshed</dt>
+            <dd class="stat-value text-2xl text-base">{{ last_refreshed|date:datetime_format|default:"?" }}</dd>
+        </div>
+        <div class="stat py-2">
+            <dt class="stat-title text-neutral-content/80">Updating every</dt>
+            <dd class="stat-value text-2xl text-base">{{ update_interval|default:"?" }}s</dd>
+        </div>
+    </dl>
+</form>


### PR DESCRIPTION
Closes #76

Add a select element for choosing the page size (max number of incident rows shown in the table). The default page size is 10 and selectable page sizes are [10, 20, 50, 100]. It is possible to override these numbers by setting the ``ARGUS_INCIDENTS_DEFAULT_PAGE_SIZE`` and ``ARGUS_INCIDENTS_PAGE_SIZES`` setting
respectively.

some noteworthy things
* hitting enter on a filterbox fields would trigger a page reload (something djang-forms maybe?). it was necessary to intercept the enter event in order to include the page_size form value, otherwise it would only send in the filter box params
* I wrapped the whole refresh-info stats element in a form, because I think we also want to make the auto-refresh frequency selectable


This PR is still a wip because I'm not quite happy with the current styling of the refresh-info, since the page-size selector increased the height. If any of you has a good styling idea, please go ahead :)