### PR TITLE
Fix broken layout of bulk modals

### DIFF
--- a/src/argus_htmx/templates/htmx/incidents/_incidents_update_menu.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incidents_update_menu.html
@@ -1,8 +1,8 @@
-<ul class="menu menu-horizontal gap-2">
+<div class="menu menu-horizontal gap-2">
     {% block update_menu_content %}
-        <li>{% include 'htmx/incidents/_incident_ticket_edit_modal.html' with dialog_id="add-ticket-dialog" button_class="btn-accent" button_title="Change tickets" header="Change tickets" explanation="Write an URL of an existing ticket, or nothing to remove existing ticket urls" cancel_text="Cancel" submit_text="Submit" %}</li>
-        <li>{% include 'htmx/incidents/_incident_acknowledge_modal.html' with dialog_id="create-acknowledgment-dialog" button_class="btn-accent" button_title="Acknowledge" header="Submit acknowledgment" explanation="Write a message describing why these incidents were acknowledged" cancel_text="Cancel" submit_text="Submit" %}</li>
-        <li>{% include 'htmx/incidents/_incident_close_modal.html' with dialog_id="close_incident-dialog" button_class="btn-accent" button_title="Close" header="Manually close incidents" explanation="Write a message describing why these incidents were manually closed" cancel_text="Cancel" submit_text="Close now" %}</li>
-        <li>{% include 'htmx/incidents/_incident_reopen_modal.html' with dialog_id="reopen-incident-dialog" button_class="btn-accent" button_title="Reopen" header="Manually reopen incidents" explanation="Write a message describing why these incidents were manually reopened" cancel_text="Cancel" submit_text="Reopen now" %}</li>
+        {% include 'htmx/incidents/_incident_ticket_edit_modal.html' with dialog_id="add-ticket-dialog" button_class="btn-accent" button_title="Change tickets" header="Change tickets" explanation="Write an URL of an existing ticket, or nothing to remove existing ticket urls" cancel_text="Cancel" submit_text="Submit" %}
+        {% include 'htmx/incidents/_incident_acknowledge_modal.html' with dialog_id="create-acknowledgment-dialog" button_class="btn-accent" button_title="Acknowledge" header="Submit acknowledgment" explanation="Write a message describing why these incidents were acknowledged" cancel_text="Cancel" submit_text="Submit" %}
+        {% include 'htmx/incidents/_incident_close_modal.html' with dialog_id="close_incident-dialog" button_class="btn-accent" button_title="Close" header="Manually close incidents" explanation="Write a message describing why these incidents were manually closed" cancel_text="Cancel" submit_text="Close now" %}
+        {% include 'htmx/incidents/_incident_reopen_modal.html' with dialog_id="reopen-incident-dialog" button_class="btn-accent" button_title="Reopen" header="Manually reopen incidents" explanation="Write a message describing why these incidents were manually reopened" cancel_text="Cancel" submit_text="Reopen now" %}
     {% endblock update_menu_content %}
-</ul>
+</div>


### PR DESCRIPTION
Closes #152, #154

The problem was due to conflicting grid layout styles between `<dialog>` (the modal box) and `.menu li` (listitem tags that modals were wrapped with).
There are alternative solutions to the one in this PR:

- break the overlap between the conflicting styles by adding another tag (layer) between listitem and modal. Achievable by adding a wrap `<div class="contents">...</div>` around modal (either directly in base template `_base_form_modal.html`, or around each `include` in `_incidents_update_menu.html`). Docs about display option contents: https://tailwindcss.com/docs/display#contents. Pros: Very strong alternative, plus it could somewhat be a failsafe against future broken placements of modals. Cons: Adds "empty" layer of nesting, aka adding structural tag purely for styling purposes
- add targeted CSS overrides and test that they work properly with existing styles