### PR TITLE
Add support for a menu of SSO login options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,7 +160,7 @@ If using ``social_core.backends.open_id_connect.OpenIdConnectAuth`` there's an
 optional setting ``ARGUS_OIDC_METHOD_NAME`` to choose what to show on the
 button.
 
-Both acn be set via environment variables.
+Both can be set via environment variables.
 
 Update
 ======

--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,6 @@ file) at minimum add::
     TEMPLATES = [
         {
             "BACKEND": "django.template.backends.django.DjangoTemplates",
-            "DIRS": [str(SITE_DIR / "templates")],
             "APP_DIRS": True,
             "OPTIONS": {
                 "debug": get_bool_env("TEMPLATE_DEBUG", False),

--- a/README.rst
+++ b/README.rst
@@ -160,6 +160,8 @@ If using ``social_core.backends.open_id_connect.OpenIdConnectAuth`` there's an
 optional setting ``ARGUS_OIDC_METHOD_NAME`` to choose what to show on the
 button.
 
+Both acn be set via environment variables.
+
 Update
 ======
 

--- a/README.rst
+++ b/README.rst
@@ -53,11 +53,14 @@ file) at minimum add::
         "django_htmx.middleware.HtmxMiddleware",
         "argus_htmx.middleware.LoginRequiredMiddleware",
     ]
-    LOGIN_URL = "/accounts/login"
+    LOGIN_URL = "/accounts/login/"
     LOGIN_REDIRECT_URL = "/incidents/"
+    LOGIN_REDIRECT_URL = "/incidents/"
+    LOGOUT_REDIRECT_URL = "/"
     PUBLIC_URLS = [
         "/accounts/login/",
         "/api/",
+        "/oidc/",
     ]
     TEMPLATES = [
         {

--- a/README.rst
+++ b/README.rst
@@ -149,6 +149,18 @@ In the file ``extra.json``, (which can be syntax checked with for instance
       }
     ]
 
+Optional authentication backend settings
+----------------------------------------
+
+If using ``django.contrib.auth.backends.RemoteUserBackend`` (which depends on
+the middleware ``django.contrib.auth.middleware.RemoteUserMiddleware``) there's
+an optional setting ``ARGUS_REMOTE_USER_METHOD_NAME`` to choose what to show on
+the button.
+
+If using ``social_core.backends.open_id_connect.OpenIdConnectAuth`` there's an
+optional setting ``ARGUS_OIDC_METHOD_NAME`` to choose what to show on the
+button.
+
 Update
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ dependencies = [
     "argus-server>=1.25.0",
     "django-htmx",
     "django-widget-tweaks==1.5.0",
+    "social-auth-core>=4.1",
+    "social-auth-app-django>=5.0",
 ]
 
 [project.urls]

--- a/src/argus_htmx/auth/views.py
+++ b/src/argus_htmx/auth/views.py
@@ -38,7 +38,7 @@ def get_htmx_authentication_backend_name_and_type():
             display_name = OIDC_METHOD_NAME
         psa_backend_data = {
             "url": reverse("social:begin", kwargs={"backend": backend.name}),
-            "display_name": backend.name,
+            "display_name": display_name,
         }
         data.setdefault("external", []).append(psa_backend_data)
 
@@ -48,7 +48,6 @@ def get_htmx_authentication_backend_name_and_type():
 class LoginView(DjangoLoginView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        urlname = "htmx:login"
         backends = get_htmx_authentication_backend_name_and_type()
         context["backends"] = backends
         return context

--- a/src/argus_htmx/auth/views.py
+++ b/src/argus_htmx/auth/views.py
@@ -1,0 +1,54 @@
+from django.conf import settings
+from django.contrib.auth.views import LoginView as DjangoLoginView
+from django.urls import reverse
+
+from argus.auth.utils import (
+    has_model_backend,
+    has_remote_user_backend,
+    get_psa_authentication_backends,
+    get_authentication_backend_classes,
+)
+
+
+REMOTE_USER_METHOD_NAME = getattr(settings, "ARGUS_REMOTE_USER_METHOD_NAME", "REMOTE_USER")
+OIDC_METHOD_NAME = getattr(settings, "ARGUS_OIDC_METHOD_NAME", "OIDC")
+
+
+def get_htmx_authentication_backend_name_and_type():
+    # Needed for HTMX LoginView
+    backends = get_authentication_backend_classes()
+
+    data = {}
+    if has_model_backend(backends):
+        data["local"] = {
+            "url": reverse("htmx:login"),
+            "display_name": "Log In",
+        }
+
+    if has_remote_user_backend(backends):
+        remote_user_data = {
+            "url": "/",  # Should probably also be a setting
+            "display_name": REMOTE_USER_METHOD_NAME,
+        }
+        data.setdefault("external", []).append(remote_user_data)
+
+    for backend in get_psa_authentication_backends(backends):
+        display_name = backend.name
+        if backend.name == "oidc":
+            display_name = OIDC_METHOD_NAME
+        psa_backend_data = {
+            "url": reverse("social:begin", kwargs={"backend": backend.name}),
+            "display_name": backend.name,
+        }
+        data.setdefault("external", []).append(psa_backend_data)
+
+    return data
+
+
+class LoginView(DjangoLoginView):
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        urlname = "htmx:login"
+        backends = get_htmx_authentication_backend_name_and_type()
+        context["backends"] = backends
+        return context

--- a/src/argus_htmx/templates/registration/login.html
+++ b/src/argus_htmx/templates/registration/login.html
@@ -1,24 +1,34 @@
 {% extends "htmx/base.html" %}
 {% load widget_tweaks %}
 {% block main %}
-  <div class="p-6 flex justify-center">
-    <div class="card border border-primary p-2 w-full sm:w-96 flex items-center">
-      <h2 class="card-title">Log In</h2>
-      <section class="card-body">
-        <form method="post" class="flex flex-col gap-6">
-          {% csrf_token %}
-          {% for field in form %}
-            <label class="flex flex-row items-center gap-2">
-              <span class="w-24">{{ field.label }}:</span>
-              <div class="indicator">
-                <span class="indicator-item indicator-top indicator-start badge border-none mask mask-circle text-warning text-base">＊</span>
-                {{ field|add_class:"input input-bordered border-accent grow" }}
-              </div>
-            </label>
-          {% endfor %}
-          <button type="submit" class="btn btn-primary">Log In</button>
-        </form>
-      </section>
-    </div>
+<div class="p-6 flex justify-center">
+  <div class="card border border-primary p-2 w-full sm:w-96 flex items-center">
+    <h2 class="card-title">Log In</h2>
+
+    <section class="card-body">
+    {% if "local" in backends %}
+    <form method="post" class="flex flex-col gap-6" action"{{ backends.local.url }}">
+      {% csrf_token %}
+      {% for field in form %}
+      <label class="flex flex-row items-center gap-2">
+        <span class="w-24">{{ field.label }}:</span>
+        <div class="indicator">
+          <span class="indicator-item indicator-top indicator-start badge border-none mask mask-circle text-warning text-base">＊</span>
+          {{ field|add_class:"input input-bordered border-accent grow" }}
+        </div>
+      </label>
+      {% endfor %}
+      <button type="submit" class="btn btn-primary">{{ backends.local.display_name }}</button>
+    </form>
+    {% endif %}
+
+    {% if backends.external %}
+    <h3>Login with</h3>
+    {% for backend in backends.external %}
+    <a class="btn btn-primary" href="{{ backend.url }}">{{ backend.display_name }}</a>
+    {% endfor %}
+    {% endif %}
+    </section>
   </div>
+</div>
 {% endblock main %}

--- a/src/argus_htmx/urls.py
+++ b/src/argus_htmx/urls.py
@@ -1,6 +1,7 @@
+from django.contrib.auth import views as django_auth_views
 from django.urls import path, include
-from django.contrib.auth import views as auth_views
 
+from .auth import views as auth_views
 from .incidents.urls import urlpatterns as incident_urls
 from .timeslots.urls import urlpatterns as timeslot_urls
 from .notificationprofiles.urls import urlpatterns as notificationprofile_urls
@@ -11,7 +12,7 @@ from .dateformat.urls import urlpatterns as dateformat_urls
 app_name = "htmx"
 urlpatterns = [
     path("accounts/login/", auth_views.LoginView.as_view(), name="login"),
-    path("accounts/logout/", auth_views.LogoutView.as_view(), name="logout"),
+    path("accounts/logout/", django_auth_views.LogoutView.as_view(), name="logout"),
     # path("accounts/", include("django.contrib.auth.urls")),
     path("incidents/", include(incident_urls)),
     path("timeslots/", include(timeslot_urls)),


### PR DESCRIPTION
See https://indieweb.org/NASCAR_problem

In order to properly test this you need one or more python social auth provider backends added to `AUTHENTICATION_BACKENDS` and the necessary KEY and SECRET set up in settings.

See argus-server docs for more info.