### PR TITLE
Add djLint to format HTML

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,3 +16,20 @@ jobs:
       with:
         args: "format --check"
         changed-files: 'true'
+
+  djlint:
+    runs-on: ubuntu-latest
+    name: Check HTML formatting
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+
+    - name: Install dependencies
+      run: |
+        pip install -U pip
+        pip install djlint
+
+    - name: Format HTML
+      run: djlint . --check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,7 @@ repos:
     - id: ruff
     # Run the formatter.
     - id: ruff-format
+-   repo: https://github.com/djlint/djLint
+    rev: v1.35.2
+    hooks:
+      - id: djlint-reformat-django

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,7 @@ output-format = "full"
 
 [tool.ruff.lint]
 select = ["E9", "F63", "F7", "F82"]
+
+[tool.djlint]
+profile="django"
+indent = 2


### PR DESCRIPTION
This adds formatting HTML with djLint to pre-commit and Github actions. 

#182 actually formats the code. 