### PR TITLE
Format codebase using djade

### DIFF
--- a/src/argus_htmx/templates/htmx/base.html
+++ b/src/argus_htmx/templates/htmx/base.html
@@ -55,7 +55,7 @@
                     {% else %}
                         <a class="btn" href="{% url 'htmx:login' %}">Log in</a>
                     {% endif %}
-                {% endblock %}
+                {% endblock userlink %}
             </div>
         </nav>
     </header>

--- a/src/argus_htmx/templates/htmx/incidents/_incident_acknowledge_modal.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_acknowledge_modal.html
@@ -1,4 +1,5 @@
 {% extends "htmx/_base_form_modal.html" %}
+
 {% block dialogform %}
     <label class="indicator input input-bordered flex items-center gap-2 w-full">Message
         <span class="indicator-item indicator-top indicator-start badge border-none mask mask-circle text-warning text-base">＊</span>

--- a/src/argus_htmx/templates/htmx/incidents/_incident_close_modal.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_close_modal.html
@@ -1,4 +1,5 @@
 {% extends "htmx/_base_form_modal.html" %}
+
 {% block dialogform %}
 <label>Reason for closing
   <input name="description" type="text" placeholder="Closing message" class="input input-bordered w-full max-w-xs" />

--- a/src/argus_htmx/templates/htmx/incidents/_incident_reopen_modal.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_reopen_modal.html
@@ -1,4 +1,5 @@
 {% extends "htmx/_base_form_modal.html" %}
+
 {% block dialogform %}
 <label>Reason for reopening
   <input name="description" type="text" placeholder="Reopening message" class="input input-bordered w-full max-w-xs" />

--- a/src/argus_htmx/templates/htmx/incidents/_incident_row.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_row.html
@@ -2,20 +2,20 @@
 	  HTMX-app
 	  {% block incident_pk %}
 	  {% include "htmx/incidents/_incident_pk.html" %}
-	  {% endblock %}
+	  {% endblock incident_pk %}
 	  {% block status %}
 	  {% include "htmx/incidents/_incident_status.html" %}
-	  {% endblock %}
+	  {% endblock status %}
 	  {% block acknowledgement %}
 	  {% include "htmx/incidents/_incident_ack.html" %}
-	  {% endblock %}
+	  {% endblock acknowledgement %}
 	  {% block tag %}
 	  {% include "htmx/incidents/_incident_tag.html" with tag="location" %}
-	  {% endblock %}
+	  {% endblock tag %}
 	  {% block start_time %}
 	  {% include "htmx/incidents/_incident_start_time.html" %}
-	  {% endblock %}
+	  {% endblock start_time %}
 	  {% block description %}
 	  {% include "htmx/incidents/_incident_description.html" %}
-	  {% endblock %}
+	  {% endblock description %}
   </li>

--- a/src/argus_htmx/templates/htmx/incidents/_incident_ticket_edit_modal.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_ticket_edit_modal.html
@@ -1,4 +1,5 @@
 {% extends "htmx/_base_form_modal.html" %}
+
 {% block dialogform %}
 <label>Change ticket
   <input name="ticket_url" value="{{ incident.ticket_url|default:"" }}" placeholder="valid url or nothing" class="input input-bordered w-full max-w-xs" />

--- a/src/argus_htmx/templates/htmx/incidents/_incident_ticket_manual_create_modal.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_ticket_manual_create_modal.html
@@ -1,4 +1,5 @@
 {% extends "htmx/_base_form_modal.html" %}
+
 {% block dialogform %}
 <label>Ticket url
    <input name="ticket_url" required placeholder="Ticket url" class="input input-bordered w-full max-w-xs"/>

--- a/src/argus_htmx/templates/htmx/incidents/incident_list.html
+++ b/src/argus_htmx/templates/htmx/incidents/incident_list.html
@@ -1,4 +1,5 @@
 {% extends base %}
+
 {% block main %}
     <section>
         {% if incidents_extra_widget %}

--- a/src/argus_htmx/templates/htmx_base.html
+++ b/src/argus_htmx/templates/htmx_base.html
@@ -25,6 +25,6 @@
 {% block footer %}
 {% endblock footer %}
 
-{% block tail %}{% endblock tail %}
+{% block tail %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
Now we can discuss if we prefer djade or djLint (#182) to format HTML files

Djade documentation: https://github.com/adamchainz/djade