### PR TITLE
Remove empty class tag

### DIFF
--- a/src/argus_htmx/templates/htmx/incidents/_incident_table.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_table.html
@@ -28,7 +28,6 @@
     </thead>
     <tbody
             id="table-body"
-            class=""
     >
     {% block incident_rows %}
         {% include 'htmx/incidents/_incident_table_rows.html' with incident_list=page.object_list %}


### PR DESCRIPTION
This is to follow rule H026 of djLint.

Reference: https://www.djlint.com/docs/linter/#rules
