### PR TITLE
Add whitespace after variable in template

### DIFF
--- a/src/argus_htmx/templates/htmx/incidents/incident_detail.html
+++ b/src/argus_htmx/templates/htmx/incidents/incident_detail.html
@@ -102,7 +102,7 @@
     {{ ack.event.actor }}
     {{ ack.event.timestamp|date:datetime_format }}
     </p>
-    {% if ack.expiration%}<p>Expires: {{ ack.expiration|date:datetime_format }}</p>{% endif %}
+    {% if ack.expiration %}<p>Expires: {{ ack.expiration|date:datetime_format }}</p>{% endif %}
     </div>
     {% endfor %}
   <div class="card-actions divide-none">


### PR DESCRIPTION
This is to follow rule T001 of djLint.

Reference: https://www.djlint.com/docs/linter/#rules
