### PR TITLE
Add F5, F6, F8 and F9 rules to ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ line-length = 120
 output-format = "full"
 
 [tool.ruff.lint]
-select = ["E7", "E9", "F63", "F7", "F82"]
+select = ["E7", "E9", "F5", "F6", "F7", "F8", "F9"]
 
 [tool.djlint]
 profile="django"


### PR DESCRIPTION
They are already fulfilled on the current codebase. 

Tagging as discussion to invite discussion if/which of these rules we want.

Reference: https://docs.astral.sh/ruff/rules/#pyflakes-f