### PR TITLE
Add E4 rules to ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ line-length = 120
 output-format = "full"
 
 [tool.ruff.lint]
-select = ["E7", "E9", "F5", "F6", "F7", "F8", "F9"]
+select = ["E4", "E7", "E9", "F5", "F6", "F7", "F8", "F9"]
 
 [tool.djlint]
 profile="django"


### PR DESCRIPTION
Codebase already fulfills these rules. 

Tagging as discussion to invite discussion if/which of these rules we want.

Reference: https://docs.astral.sh/ruff/rules/#error-e