### PR TITLE
Add meta description and keywords

### DIFF
--- a/src/argus_htmx/templates/htmx_base.html
+++ b/src/argus_htmx/templates/htmx_base.html
@@ -5,6 +5,8 @@
   <head>
     <meta name="description"
           content="Argus is a tool for aggregating events from multiple monitoring applications into a single, unified dashboard and notification system.">
+    <meta name="keywords"
+          content="monitoring, notifications, dashboard, events, incidents, alerts, alarms, monitoring systems, monitoring applications, monitoring tools, monitoring software">
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {% block title %}


### PR DESCRIPTION
Fixes complaints regarding rules H030 and H031 for #180.

Adding rules `H030` and `H031` is very much nice-to-have-borderline-redundant as they concern [search engine optimization](https://developer.mozilla.org/en-US/docs/Glossary/SEO). Argus runs in different instances and requires authentication so SEO is not a concern IMO.

Meta keywords aren't even used as of now https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML#adding_an_author_and_description.