### PR TITLE
Remove D018 (urlpatterns format) from ignored linter rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,4 +45,4 @@ select = ["E4", "E7", "E9", "F4", "F5", "F6", "F7", "F8", "F9"]
 [tool.djlint]
 profile="django"
 indent = 2
-ignore="H006,D018"
+ignore="H006"


### PR DESCRIPTION
Rule D018: `(Django) Internal links should use the {% url ... %} pattern.` (https://www.djlint.com/docs/linter/#rules) 

This was only temporarily introduced until #186 could be merged