### PR TITLE
Remove selected rules from ruff config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   ruff:
     runs-on: ubuntu-latest
-    name: Critical lint Python
+    name: Lint Python
     steps:
     - uses: actions/checkout@v4
     - uses: astral-sh/ruff-action@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,6 @@ name = "argus_htmx"
 line-length = 120
 output-format = "full"
 
-[tool.ruff.lint]
-select = ["E4", "E7", "E9", "F4", "F5", "F6", "F7", "F8", "F9"]
-
 [tool.djlint]
 profile="django"
 indent = 2


### PR DESCRIPTION
We are using the default rules by now (see: https://docs.astral.sh/ruff/configuration/ and https://docs.astral.sh/ruff/rules/)

Also renames the Python linting workflow to not mention `critical` anymore since we're now linting for more than just critical rules. 