### PR TITLE
Make sure to reset checkbox state on some browsers (eg. firefox)

### DIFF
--- a/src/argus_htmx/templates/htmx/incidents/_incident_checkbox.html
+++ b/src/argus_htmx/templates/htmx/incidents/_incident_checkbox.html
@@ -2,6 +2,7 @@
 <input id="select-incident-{{ incident.pk }}"
        hx-preserve
        type="checkbox"
+       autocomplete="off"
        class="row-select checkbox checkbox-sm checkbox-accent border"
        hx-on:change="event.target.checked ? htmx.find('.tab-select').checked = event.target.checked : null;"
        name="incident_ids"


### PR DESCRIPTION
On some browsers (at least Firefox), the multiselect checkbox state is remembered after a bulk action, depending on the current incident filter, the remberbed selected checkboxes may now be for a completely different incident. We should make sure to reset the checkbox state