### PR TITLE
Set default timestamp field when this is an optional field in a bulk action form

### DIFF
--- a/src/argus_htmx/utils.py
+++ b/src/argus_htmx/utils.py
@@ -80,7 +80,7 @@ def bulk_change_incidents(actor, incident_ids: List[int], data: Dict[str, Any], 
     - We're working on a subset of incidents and the ids are not in that subset
     """
     qs, missing_ids = get_qs_for_incident_ids(incident_ids, qs)
-    if "timestamp" not in data:
+    if not data.get("timestamp"):
         data["timestamp"] = timezone.now()
     incidents = func(actor, qs, data)
     send_changed_incidents(incidents)


### PR DESCRIPTION
When using a bulk action form that has an optional `timestamp` field, the form validation logic sets this value as `None`. It should then be filled with a default timestamp